### PR TITLE
Feat: 각 정보에 대한 카드 섹션 추가 및 경로명 변경

### DIFF
--- a/src/components/home/FinanceSection.vue
+++ b/src/components/home/FinanceSection.vue
@@ -1,0 +1,29 @@
+<script setup>
+const financeCards = [
+  { image: 'finance-image1.jpg', description: '금융 설명 1' },
+  { image: 'finance-image2.jpg', description: '금융 설명 2' },
+  { image: 'finance-image3.jpg', description: '금융 설명 3' },
+];
+</script>
+
+<template>
+  <div class="section mb-6">
+    <h2 class="text-2xl font-bold text-blue-900 mb-4">금융 정보</h2>
+    <div class="cards flex overflow-x-scroll space-x-4">
+      <div v-for="(card, index) in financeCards" :key="index" class="card bg-blue-800 text-white p-4 rounded-lg w-64 flex-shrink-0">
+        <img :src="card.image" alt="금융 이미지" class="mb-2 rounded-md" />
+        <p class="text-base">{{ card.description }}</p>
+      </div>
+    </div>
+    <router-link to="/finance" class="block mt-2 text-right text-blue-700 hover:underline">더보기</router-link>
+  </div>
+</template>
+
+<style scoped>
+.card {
+  transition: transform 0.3s;
+}
+.card:hover {
+  transform: translateY(-5px);
+}
+</style>

--- a/src/components/home/PolicySection.vue
+++ b/src/components/home/PolicySection.vue
@@ -1,0 +1,29 @@
+<script setup>
+const policyCards = [
+  { image: 'policy-image1.jpg', description: '정책 설명 1' },
+  { image: 'policy-image2.jpg', description: '정책 설명 2' },
+  { image: 'policy-image3.jpg', description: '정책 설명 3' },
+];
+</script>
+
+<template>
+  <div class="section mb-6">
+    <h2 class="text-2xl font-bold text-blue-900 mb-4">정책 정보</h2>
+    <div class="cards flex overflow-x-scroll space-x-4">
+      <div v-for="(card, index) in policyCards" :key="index" class="card bg-blue-800 text-white p-4 rounded-lg w-64 flex-shrink-0">
+        <img :src="card.image" alt="정책 이미지" class="mb-2 rounded-md" />
+        <p class="text-base">{{ card.description }}</p>
+      </div>
+    </div>
+    <router-link to="/policy" class="block mt-2 text-right text-blue-700 hover:underline">더보기</router-link>
+  </div>
+</template>
+
+<style scoped>
+.card {
+  transition: transform 0.3s;
+}
+.card:hover {
+  transform: translateY(-5px);
+}
+</style>

--- a/src/components/home/SubscriptionSection.vue
+++ b/src/components/home/SubscriptionSection.vue
@@ -1,0 +1,29 @@
+<script setup>
+const realEstateCards = [
+  { image: 'realestate-image1.jpg', description: '부동산 설명 1' },
+  { image: 'realestate-image2.jpg', description: '부동산 설명 2' },
+  { image: 'realestate-image3.jpg', description: '부동산 설명 3' },
+];
+</script>
+
+<template>
+  <div class="section mb-6">
+    <h2 class="text-2xl font-bold text-blue-900 mb-4">부동산 정보</h2>
+    <div class="cards flex overflow-x-scroll space-x-4">
+      <div v-for="(card, index) in realEstateCards" :key="index" class="card bg-blue-800 text-white p-4 rounded-lg w-64 flex-shrink-0">
+        <img :src="card.image" alt="부동산 이미지" class="mb-2 rounded-md" />
+        <p class="text-base">{{ card.description }}</p>
+      </div>
+    </div>
+    <router-link to="/subscription" class="block mt-2 text-right text-blue-700 hover:underline">더보기</router-link>
+  </div>
+</template>
+
+<style scoped>
+.card {
+  transition: transform 0.3s;
+}
+.card:hover {
+  transform: translateY(-5px);
+}
+</style>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -14,7 +14,7 @@ export default {
     },
     {
       title: "금융",
-      url: "/economy",
+      url: "/finance",
       icon: ["fas", "money-bill"],
     },
   ],

--- a/src/router/economy.js
+++ b/src/router/economy.js
@@ -1,7 +1,0 @@
-export default [
-    {
-        path: "/economy",
-        name: "economy",
-        component: () => import("../views/economy/EconomyInsightPage.vue"),
-    },
-];

--- a/src/router/finance.js
+++ b/src/router/finance.js
@@ -1,0 +1,7 @@
+export default [
+    {
+        path: "/finance",
+        name: "finance",
+        component: () => import("../views/finance/FinanceInsightPage.vue"),
+    },
+];

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import HomePage from '../views/HomePage.vue'
 import authRotes from "./auth";
 import policyRotes from "./policy";
-import economyRoutes from "./economy";
+import financeRoutes from "./finance";
 import subscriptionRoutes from './subscription';
 
 const router = createRouter({
@@ -15,7 +15,7 @@ const router = createRouter({
     },
     ...authRotes,
     ...policyRotes,
-    ...economyRoutes,
+    ...financeRoutes,
     ...subscriptionRoutes
   ]
 })

--- a/src/stores/home.js
+++ b/src/stores/home.js
@@ -1,0 +1,25 @@
+import { defineStore } from 'pinia';
+
+export const useHomeStore = defineStore('home', {
+  state: () => ({
+    policyCards: [
+      { image: 'policy-image1.jpg', description: '정책 설명 1' },
+      { image: 'policy-image2.jpg', description: '정책 설명 2' },
+      { image: 'policy-image3.jpg', description: '정책 설명 3' },
+    ],
+    realEstateCards: [
+      { image: 'realestate-image1.jpg', description: '부동산 설명 1' },
+      { image: 'realestate-image2.jpg', description: '부동산 설명 2' },
+      { image: 'realestate-image3.jpg', description: '부동산 설명 3' },
+    ],
+    financeCards: [
+      { image: 'finance-image1.jpg', description: '금융 설명 1' },
+      { image: 'finance-image2.jpg', description: '금융 설명 2' },
+      { image: 'finance-image3.jpg', description: '금융 설명 3' },
+    ],
+  }),
+  actions: {
+    fetchCards() {
+    },
+  },
+});

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -1,4 +1,17 @@
-<script setup></script>
+<script setup>
+import PolicySection from '@/components/home/PolicySection.vue';
+import SubscriptionSection from '@/components/home/SubscriptionSection.vue';
+import FinanceSection from '@/components//home/FinanceSection.vue';
+</script>
+
 <template>
-    <h1>첫번째 페이지</h1>
+  <div class="homepage container mx-auto p-4">
+    <PolicySection />
+    <SubscriptionSection />
+    <FinanceSection />
+  </div>
 </template>
+
+<style scoped>
+
+</style>

--- a/src/views/finance/FinanceInsightPage.vue
+++ b/src/views/finance/FinanceInsightPage.vue
@@ -1,5 +1,5 @@
 <template>
-    <h1>economy</h1>
+    <h1>finance</h1>
 </template>
 <script setup></script>
 <style></style>


### PR DESCRIPTION
### #️⃣ 24.11.08

### 📝 작업 내용
- /economy를 /finance로 경로명, 파일명 변경
- 금융, 정책, 부동산 정보 카드 섹션 추가:
  - FinanceSection.vue: 금융 카드 목록 및 상세 페이지 링크 추가
  - PolicySection.vue: 정책 카드 목록 및 상세 페이지 링크 추가
  - SubscriptionSection.vue: 부동산 카드 목록 및 상세 페이지 링크 추가
  - 
### 💬 리뷰 요구사항
- 모든 관련 컴포넌트에서 카드 목록이 정상적으로 표시되고, 각 카드의 링크가 올바르게 작동하는지 확인해 주세요

### 스크린샷
![image](https://github.com/user-attachments/assets/f4a03fe1-aadd-4f14-9c6c-f27337b398bc)
