### PR TITLE
Feat: 홈 화면 금융, 청약 연동

### DIFF
--- a/src/components/home/BannerSlider.vue
+++ b/src/components/home/BannerSlider.vue
@@ -19,7 +19,7 @@ const banners = ref([
     subtitle: "AI로 더 빠르고 똑똑하게 정책 확인",
     title: "청사진",
     link: "#",
-    backgroundColor: 'bg-yellow-500',
+    backgroundColor: 'bg-yellow-400',
   },
   {
     subtitle: "자산 관리 서비스",
@@ -71,7 +71,7 @@ const modules = [Autoplay, Pagination];
 .mySwiper {
   width: 100%;
   max-width: 100%;
-  height: 300px;
+  height: 350px;
   margin: 0;
 }
 .swiper-slide {

--- a/src/components/home/PolicySection.vue
+++ b/src/components/home/PolicySection.vue
@@ -93,7 +93,7 @@ const slidePrev = () => {
 
 <template>
   <section class="mt-8 relative">
-    <h2 class="text-2xl font-bold mb-12 text-center">정책 정보</h2>
+    <h2 class="text-2xl font-bold mb-8 text-center">정책 정보</h2>
     <div class="flex items-center">
       <button 
         @click="slidePrev" 
@@ -137,7 +137,7 @@ const slidePrev = () => {
       </button>
     </div>
 
-    <div class="flex justify-center mt-6">
+    <div class="flex justify-end mt-6">
       <button 
         @click="router.push('/policy')" 
         class="px-4 py-2 rounded-lg hover:bg-blue-200 hover:transition duration-200 font-semibold border"

--- a/src/components/home/SubscriptionSection.vue
+++ b/src/components/home/SubscriptionSection.vue
@@ -6,19 +6,21 @@ export default {
   setup() {
     const store = useSubscriptionStore();
     const subscriptionList = ref([]);
+    const currentSlideIndex = ref(0);
+    const visibleCards = ref(3);
 
     const today = new Date();
     const oneWeekLater = new Date();
     oneWeekLater.setDate(today.getDate() + 7);
 
     const formatDate = (dateString) => {
-      const options = { year: 'numeric', month: 'long', day: 'numeric' };
-      return new Date(dateString).toLocaleDateString('ko-KR', options);
+      const options = { year: "numeric", month: "long", day: "numeric" };
+      return new Date(dateString).toLocaleDateString("ko-KR", options);
     };
 
     const filteredSubscriptionList = computed(() => {
       return subscriptionList.value
-        .filter(item => {
+        .filter((item) => {
           const endDate = new Date(item.rceptEndde);
           return endDate >= today && endDate <= oneWeekLater;
         })
@@ -30,24 +32,45 @@ export default {
       const endDate = new Date(item.rceptEndde);
 
       if (endDate.toDateString() === today.toDateString()) {
-        return 'border border-red-500'; 
+        return "border border-red-500";
       } else if (startDate <= today && endDate >= today) {
-        return 'border border-blue-700'; 
+        return "border border-[#0E429D]";
       } else {
-        return 'border border-gray-300'; 
+        return "border border-gray-400";
       }
     };
 
     const nextSlide = () => {
-      document.querySelector(".cards").scrollBy({ left: 300, behavior: "smooth" });
+      const maxIndex = Math.max(0, filteredSubscriptionList.value.length - visibleCards.value);
+      if (currentSlideIndex.value < maxIndex) {
+        currentSlideIndex.value += 1;
+      }
     };
+
     const prevSlide = () => {
-      document.querySelector(".cards").scrollBy({ left: -300, behavior: "smooth" });
+      if (currentSlideIndex.value > 0) {
+        currentSlideIndex.value -= 1;
+      }
+    };
+
+    const updateVisibleCards = () => {
+      const width = window.innerWidth;
+      if (width < 768) {
+        visibleCards.value = 1;
+      } else if (width < 1024) {
+        visibleCards.value = 2; 
+      } else if (width < 1440) {
+        visibleCards.value = 3;
+      } else {
+        visibleCards.value = 4;
+      }
     };
 
     onMounted(async () => {
       await store.getSubscription();
       subscriptionList.value = store.subscription;
+      updateVisibleCards();
+      window.addEventListener("resize", updateVisibleCards);
     });
 
     return {
@@ -56,6 +79,8 @@ export default {
       getBorderStyle,
       nextSlide,
       prevSlide,
+      currentSlideIndex,
+      visibleCards,
     };
   },
 };
@@ -63,50 +88,82 @@ export default {
 
 <template>
   <div class="section mt-20">
-    <h2 class="text-2xl font-bold mb-12 text-center">다가오는 청약 정보</h2>
-    <div class="flex items-center justify-center space-x-4">
+    <h2 class="text-2xl font-bold mb-8 text-center">다가오는 청약</h2>
+    <div class="flex items-center justify-center relative space-x-4">
 
-      <button class="p-2 bg-gray-200 rounded-full shadow hover:bg-gray-300" @click="prevSlide">
+      <!-- 왼쪽 버튼 -->
+      <button
+        class="p-2 bg-gray-200 rounded-full shadow hover:bg-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="currentSlideIndex === 0"
+        @click="prevSlide"
+      >
         <i class="fas fa-chevron-left"></i>
       </button>
 
-      <div class="cards flex overflow-x-auto w-full mx-4 space-x-4">
+      <!-- 카드 컨테이너 -->
+      <div class="overflow-hidden w-full">
         <div
-          v-for="(item, index) in filteredSubscriptionList"
-          :key="item.idx"
-          :class="['card cursor-pointer bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 p-4 flex-shrink-0', getBorderStyle(item)]"
+          class="grid transition-transform duration-300 gap-4"
+          :style="{
+            transform: `translateX(-${currentSlideIndex * (100 / visibleCards)}%)`,
+            gridTemplateColumns: `repeat(${filteredSubscriptionList.length}, 1fr)`
+          }"
         >
-          <h3 class="text-lg font-semibold mb-2 text-center">{{ item.name }}</h3>
-          <div v-if="item.houseDtlSecd" class="text-gray-500 text-sm bg-gray-100 rounded-full px-3 py-1 inline-block mt-2 text-center">
-            {{ item.houseDtlSecd }}
-          </div>
-          <div class="text-center text-gray-700 mt-4 space-y-2 text-sm">
-            <p>시작일: {{ formatDate(item.rceptBgnde) }}</p>
-            <p>종료일: {{ formatDate(item.rceptEndde) }}</p>
-            <p v-if="item.region || item.city || item.district">
-              <span>{{ item.region }}</span>
-              <span v-if="item.city">, {{ item.city }}</span>
-              <span v-if="item.district">, {{ item.district }}</span>
-            </p>
-          </div>
-          <div class="text-right mt-4 absolute bottom-4 right-4">
-            <a
-              :href="item.pblancUrl"
-              class="text-blue-500 underline"
-              target="_blank"
-              rel="noopener noreferrer"
-            >상세 정보 페이지</a>
+
+          <div
+            v-for="(item, index) in filteredSubscriptionList"
+            :key="item.idx"
+            :class="['card bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow p-4', getBorderStyle(item)]"
+          >
+          <div
+              v-if="item.houseDtlSecd"
+              class="text-sm bg-gray-100 rounded-full px-3 py-1 inline-block mb-2 text-center"
+              style="background-color: #C1D5F9; color: white;"
+              >
+              {{ item.houseDtlSecd }}
+            </div>
+            <h3 class="text-lg font-semibold mb-2 text-center">{{ item.name }}</h3>
+            
+            <div class="text-center text-gray-700 mt-4 space-y-2 text-sm">
+              <p v-if="item.region || item.city || item.district">
+                <span>{{ item.region }}</span>
+                <span v-if="item.city">, {{ item.city }}</span>
+                <span v-if="item.district">, {{ item.district }}</span>
+              </p>
+              <br>
+              <p><strong>시작일</strong> {{ formatDate(item.rceptBgnde) }}</p>
+              <p><strong>종료일</strong> {{ formatDate(item.rceptEndde) }}</p>
+            </div>
+            <div class="text-right mt-4 absolute bottom-4 right-4">
+              <a
+                :href="item.pblancUrl"
+                class="text-blue-500 underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                상세 정보 페이지
+              </a>
+            </div>
           </div>
         </div>
       </div>
 
-      <button class="p-2 bg-gray-200 rounded-full shadow hover:bg-gray-300" @click="nextSlide">
+      <!-- 오른쪽 버튼 -->
+      <button
+        class="p-2 bg-gray-200 rounded-full shadow hover:bg-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="currentSlideIndex >= filteredSubscriptionList.length - visibleCards"
+        @click="nextSlide"
+      >
         <i class="fas fa-chevron-right"></i>
       </button>
     </div>
 
-    <div class="flex justify-center mt-6" v-if="filteredSubscriptionList.length > 0">
-      <router-link to="/subscription" class="px-4 py-2 rounded-lg hover:bg-blue-200 hover:transition duration-200 font-semibold border">
+    <!-- 더보기 -->
+    <div class="flex justify-end mt-6" v-if="filteredSubscriptionList.length > 0">
+      <router-link
+        to="/subscription"
+        class="px-4 py-2 rounded-lg hover:bg-blue-200 hover:transition duration-200 font-semibold border"
+      >
         더보기
       </router-link>
     </div>
@@ -120,23 +177,29 @@ export default {
   min-width: 300px;
   max-width: 300px;
   min-height: 300px;
-  flex-shrink: 0;
-  scroll-snap-align: start;
-  transition: transform 0.3s;
   text-align: center;
   position: relative;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
+
 .card:hover {
-  transform: translateY(-5px);
+  transform: translateY(-1px);
+  box-shadow: 0px 4px 15px rgba(0, 0, 0, 0.2);
 }
+
 button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
 @media (max-width: 768px) {
+  .section {
+    padding: 0 1rem;
+  }
   .card {
     width: 100%;
-    margin-bottom: 1rem;
+    margin: 0 auto;
   }
 }
 </style>
+

--- a/src/components/layouts/NavBar.vue
+++ b/src/components/layouts/NavBar.vue
@@ -155,7 +155,7 @@ const handleLogout = () => {
       <ul class="w-full space-y-6 text-center">
         <li class="border-b border-gray-600 py-2">
           <router-link
-            to="/my-service"
+            to="/member/myService"
             class="text-white hover:text-gray-200 transition-colors duration-200"
             @click="toggleNavShow"
           >

--- a/src/stores/finance.js
+++ b/src/stores/finance.js
@@ -6,6 +6,8 @@ export const useFinanceStore = defineStore("finance", {
   state: () => ({
     SavingsList: [],
     LoanList: [],
+    AllSavingsList: [],
+    AllLoanList: [],
   }),
 
   actions: {
@@ -19,7 +21,7 @@ export const useFinanceStore = defineStore("finance", {
         });
         this.SavingsList = response.data.response.data;
       } catch (error) {
-        console.error("Failed to fetch savings filtering : ", error);
+        console.error("Failed to fetch savings filtering: ", error);
         throw error;
       }
     },
@@ -34,7 +36,37 @@ export const useFinanceStore = defineStore("finance", {
         });
         this.LoanList = response.data.response.data;
       } catch (error) {
-        console.error("Failed to fetch loan filtering : ", error);
+        console.error("Failed to fetch loan filtering: ", error);
+        throw error;
+      }
+    },
+
+    async getAllSavings() {
+      try {
+        const token = useAuthStore().token;
+        const response = await axiosInstance.get("/finance/getAllSavings", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        this.AllSavingsList = response.data.response.data;
+      } catch (error) {
+        console.error("Failed to fetch all savings: ", error);
+        throw error;
+      }
+    },
+
+    async getAllLoans() {
+      try {
+        const token = useAuthStore().token;
+        const response = await axiosInstance.get("/finance/getAllLoans", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        this.AllLoanList = response.data.response.data;
+      } catch (error) {
+        console.error("Failed to fetch all loans: ", error);
         throw error;
       }
     },

--- a/src/stores/subscription.js
+++ b/src/stores/subscription.js
@@ -9,7 +9,7 @@ export const useSubscriptionStore = defineStore("subscription",{
 actions: {
     async getSubscription() {
         try{
-            const response = await axios.get("http://localhost:8080/subscription/get")
+            const response = await axios.get("http://localhost:8080/subscription/getAll")
             this.subscription = response.data.response.data;
         } catch (error) {
             console.log("Error fetching subscription data:", error);

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -21,11 +21,11 @@ const handleFilterChanged = (policies) => {
     <BannerSlider />
   </div>
   <div class="homepage container mx-auto p-4">
-    <FilterSection @filterChanged="handleFilterChanged" class="mb-32" />
-    <FilterResult v-if="searchExecuted" :filteredPolicies="filteredPolicies" class="mb-32" />
-    <PolicySection class="mb-32" />
-    <SubscriptionSection class="mb-32" />
-    <FinanceSection class="mb-32" />
+    <FilterSection @filterChanged="handleFilterChanged" class="mb-20" />
+    <FilterResult v-if="searchExecuted" :filteredPolicies="filteredPolicies" class="mb-20" />
+    <PolicySection class="mb-20" />
+    <SubscriptionSection class="mb-20" />
+    <FinanceSection class="mb-20" />
   </div>
 </template>
 

--- a/src/views/subscription/RealEstatePage.vue
+++ b/src/views/subscription/RealEstatePage.vue
@@ -1,85 +1,3 @@
-<template>
-    <div class="chart-wrapper">
-    <div class="chart-container">
-      <div class="location-selector">
-        <div class="select-group">
-          <label>시/도</label>
-          <select 
-            v-model="selectedRegion" 
-            @change="onRegionChange" 
-            class="select-box" 
-            :disabled="loading"
-          >
-            <option value="">시/도 선택</option>
-            <option 
-              v-for="region in regions" 
-              :key="region" 
-              :value="region"
-            >
-              {{ region }}
-            </option>
-          </select>
-        </div>
-  
-        <div class="select-group">
-          <label>시/군/구</label>
-          <select 
-            v-model="selectedSgg" 
-            @change="onSggChange" 
-            class="select-box" 
-            :disabled="!selectedRegion || loading"
-          >
-            <option value="">시/군/구 선택</option>
-            <option 
-              v-for="sgg in sggList" 
-              :key="sgg" 
-              :value="sgg"
-            >
-              {{ sgg }}
-            </option>
-          </select>
-        </div>
-  
-        <div class="select-group">
-          <label>읍/면/동</label>
-          <select 
-            v-model="selectedUmd" 
-            @change="onUmdChange" 
-            class="select-box" 
-            :disabled="!selectedSgg || loading"
-          >
-            <option value="">읍/면/동 선택</option>
-            <option 
-              v-for="umd in umdList" 
-              :key="umd" 
-              :value="umd"
-            >
-              {{ umd }}
-            </option>
-          </select>
-        </div>
-      </div>
-  
-      <div class="location-info" v-if="selectedRegion && selectedSgg && selectedUmd">
-        <h2>{{ selectedRegion }} {{ selectedSgg }} {{ selectedUmd }} 부동산 현황</h2>
-      </div>
-  
-      <div v-if="!selectedRegion || !selectedSgg || !selectedUmd" class="guide-message">
-        지역을 선택해주세요.
-      </div>
-  
-      <canvas ref="chartCanvas" v-show="selectedRegion && selectedSgg && selectedUmd"></canvas>
-      
-      <div v-if="error" class="error-message">
-        {{ error }}
-      </div>
-      <div v-if="loading" class="loading-message">
-        데이터를 불러오는 중...
-      </div>
-    </div>
-</div>
-  </template>
-  
   <script setup>
   import { ref, onMounted } from "vue";
   import { getRegions, getSggList, getUmdList, getRealEstateSummary, handleApiError } from "@/util/axiosInstance";
@@ -282,131 +200,213 @@
     await initializeLocationData();
   });
   </script>
-  
-  <style scoped>
- .chart-wrapper {
+
+<template>
+  <div class="chart-wrapper">
+  <div class="chart-container">
+    <div class="location-selector">
+      <div class="select-group">
+        <label>시/도</label>
+        <select 
+          v-model="selectedRegion" 
+          @change="onRegionChange" 
+          class="select-box" 
+          :disabled="loading"
+        >
+          <option value="">시/도 선택</option>
+          <option 
+            v-for="region in regions" 
+            :key="region" 
+            :value="region"
+          >
+            {{ region }}
+          </option>
+        </select>
+      </div>
+
+      <div class="select-group">
+        <label>시/군/구</label>
+        <select 
+          v-model="selectedSgg" 
+          @change="onSggChange" 
+          class="select-box" 
+          :disabled="!selectedRegion || loading"
+        >
+          <option value="">시/군/구 선택</option>
+          <option 
+            v-for="sgg in sggList" 
+            :key="sgg" 
+            :value="sgg"
+          >
+            {{ sgg }}
+          </option>
+        </select>
+      </div>
+
+      <div class="select-group">
+        <label>읍/면/동</label>
+        <select 
+          v-model="selectedUmd" 
+          @change="onUmdChange" 
+          class="select-box" 
+          :disabled="!selectedSgg || loading"
+        >
+          <option value="">읍/면/동 선택</option>
+          <option 
+            v-for="umd in umdList" 
+            :key="umd" 
+            :value="umd"
+          >
+            {{ umd }}
+          </option>
+        </select>
+      </div>
+    </div>
+
+    <div class="location-info" v-if="selectedRegion && selectedSgg && selectedUmd">
+      <h2>{{ selectedRegion }} {{ selectedSgg }} {{ selectedUmd }} 부동산 현황</h2>
+    </div>
+
+    <div v-if="!selectedRegion || !selectedSgg || !selectedUmd" class="guide-message">
+      지역을 선택해주세요.
+    </div>
+
+    <canvas ref="chartCanvas" v-show="selectedRegion && selectedSgg && selectedUmd"></canvas>
+    
+    <div v-if="error" class="error-message">
+      {{ error }}
+    </div>
+    <div v-if="loading" class="loading-message">
+      데이터를 불러오는 중...
+    </div>
+  </div>
+</div>
+</template>
+
+<style scoped>
+.chart-wrapper {
   width: 100%;
-  margin-bottom: 4rem; /* Footer와의 간격 증가 */
+  margin-bottom: 4rem;
 }
 
 .chart-container {
   position: relative;
   width: 100%;
-  min-height: 600px; /* 최소 높이 설정 */
-  height: auto; /* 자동 높이 조정 */
+  min-height: 600px;
+  height: auto; 
   padding: 20px;
   background-color: white;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
-  
-  .location-selector {
-    display: flex;
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-    justify-content: center;
-    flex-wrap: wrap;
-  }
-  
-  .select-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  
-  .select-group label {
-    font-size: 0.9rem;
-    color: #666;
-    font-weight: 500;
-  }
-  
-  .select-box {
-    padding: 0.5rem;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    font-size: 1rem;
-    min-width: 150px;
-    background-color: white;
-    cursor: pointer;
-  }
-  
-  .select-box:disabled {
-    background-color: #f5f5f5;
-    cursor: not-allowed;
-  }
-  
-  .select-box:focus {
-    border-color: #4a90e2;
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
-  }
-  
-  .guide-message {
-    text-align: center;
-    padding: 2rem;
-    color: #666;
-    background-color: #f8f9fa;
-    border-radius: 4px;
-    margin: 2rem 0;
-  }
-  
-  .location-info {
-    text-align: center;
-    margin-bottom: 20px;
-  }
-  
-  .location-info h2 {
-    font-size: 1.5rem;
-    color: #333;
-    margin: 0;
-  }
-  
-  .error-message {
-    color: #dc3545;
-    text-align: center;
-    padding: 1rem;
-    background-color: #f8d7da;
-    border-radius: 4px;
-    margin-top: 1rem;
-  }
-  
-  .loading-message {
-    text-align: center;
-    padding: 1rem;
-    color: #666;
-    background-color: #f8f9fa;
-    border-radius: 4px;
-    margin-top: 1rem;
-  }
-
-  canvas {
-  width: 100% !important;
-  height: 400px !important; /* 고정 높이 설정 */
-  margin-top: 2rem;
-}
 
 .location-selector {
-  margin-bottom: 1.5rem;
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.select-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.select-group label {
+  font-size: 0.9rem;
+  color: #666;
+  font-weight: 500;
+}
+
+.select-box {
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  min-width: 150px;
+  background-color: white;
+  cursor: pointer;
+}
+
+.select-box:disabled {
+  background-color: #f5f5f5;
+  cursor: not-allowed;
+}
+
+.select-box:focus {
+  border-color: #4a90e2;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
 }
 
 .guide-message {
-  min-height: 200px; /* 가이드 메시지 최소 높이 */
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+  background-color: #f8f9fa;
+  border-radius: 4px;
+  margin: 2rem 0;
+}
+
+.location-info {
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.location-info h2 {
+  font-size: 1.5rem;
+  color: #333;
+  margin: 0;
+}
+
+.error-message {
+  color: #dc3545;
+  text-align: center;
+  padding: 1rem;
+  background-color: #f8d7da;
+  border-radius: 4px;
+  margin-top: 1rem;
+}
+
+.loading-message {
+  text-align: center;
+  padding: 1rem;
+  color: #666;
+  background-color: #f8f9fa;
+  border-radius: 4px;
+  margin-top: 1rem;
+}
+
+canvas {
+  width: 100% !important;
+  height: 400px !important;
+  margin-top: 2rem;
 }
 
 @media (max-width: 768px) {
-  .chart-wrapper {
-    margin-bottom: 2rem;
+  .location-selector {
+    flex-direction: column; 
+    align-items: center; 
+    gap: 1rem;
   }
 
-  .chart-container {
-    min-height: 500px;
-  }
-
-  canvas {
-    height: 300px !important;
+  .select-group {
+    width: 90%;
   }
 }
-  </style>
+
+@media (min-width: 769px) {
+  .location-selector {
+    flex-direction: row;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 2rem;
+  }
+
+  .select-group {
+    width: auto;
+  }
+}
+</style>


### PR DESCRIPTION
### #️⃣ 24.11.16

### 📝 작업 내용
- 저축 상품
    - finPrdtNm을 기반으로 "예금", "적금", "상품"을 표시
- 대출 상품
    - prdCategory에 따라서 mortgage: "주택 담보 대출",  rentHouse: "전세 자금 대출", 기타 값: "기타 대출" 로 표시
    - lend_rate_type_nm 필드로 "대출 금리 유형"을 표시
- 금융 상품 랜덤화 및 캐싱 로직
    - 캐싱된 데이터를 랜덤으로 정렬하여 랜더링 성능 최적화
- 홈 화면 UI/UX 개선
- 모바일 반응형에서 나만의 서비스 /member/myService 로 변경

### 💬 리뷰 요구사항
디자인 수정 필요한 부분이 있다면 알려주세요

### 스크린샷
![image](https://github.com/user-attachments/assets/b5e1a845-ed5d-408c-904f-8767edcd02d2)

![image](https://github.com/user-attachments/assets/9907f54b-3709-4b3c-9680-a9d17603e879)
