### PR TITLE
Feat: 맞춤형 정책 추천 기능 & Fix: 정책 페이지네이션 & Design: 구현한 페이지 UI

### DIFF
--- a/src/stores/policy.js
+++ b/src/stores/policy.js
@@ -24,6 +24,9 @@ export const usePolicyStore = defineStore("policy", {
       way: null,
       document: null,
       url: null,
+      minAge: null,
+      maxAge: null,
+      job: null,
     },
   }),
 
@@ -64,6 +67,9 @@ export const usePolicyStore = defineStore("policy", {
           way: policy.way,
           document: policy.document,
           url: policy.url,
+          minAge: policy.minAge,
+          maxAge: policy.maxAge,
+          job: policy.job,
         };
       } catch (error) {
         console.error("Failed to fetch Policy Detail: ", error);

--- a/src/stores/subscription.js
+++ b/src/stores/subscription.js
@@ -1,9 +1,12 @@
 import { defineStore } from "pinia";
 import axios from "axios";
+import axiosInstance from "@/util/axiosInstance";
+import { useAuthStore } from "@/stores/auth";
 
 export const useSubscriptionStore = defineStore("subscription",{
     state:()=>({
         subscription: [],
+        RecommedSubscriptionList: [],
     }),
 
 actions: {
@@ -14,6 +17,21 @@ actions: {
         } catch (error) {
             console.log("Error fetching subscription data:", error);
         }
-    }
+    },
+
+    async getRecommendSubscription() {
+        try {
+          const token = useAuthStore().token;
+          const response = await axiosInstance.get("/subscription/recommendation", {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          });
+          this.RecommedSubscriptionList = response.data.response.data;
+        } catch (error) {
+          console.error("Failed to recommend subscription : ", error);
+          throw error;
+        }
+      },
 }
 });

--- a/src/views/auth/LoginPage.vue
+++ b/src/views/auth/LoginPage.vue
@@ -32,6 +32,13 @@ const login = async () => {
       localStorage.removeItem("selectedJob");
       localStorage.removeItem("selectedName");
       localStorage.removeItem("page");
+
+      localStorage.setItem("selectedCity", null);
+      localStorage.setItem("district", "");
+      localStorage.setItem("selectedPolicyType", null);
+      localStorage.setItem("selectedAge", "");
+      localStorage.setItem("selectedJob", null);
+      localStorage.setItem("selectedName", "");
       axiosInstance.defaults.headers.common[
         "Authorization"
       ] = `Bearer ${auth.token}`;

--- a/src/views/auth/MyService.vue
+++ b/src/views/auth/MyService.vue
@@ -134,17 +134,19 @@ onMounted(async () => {
       님을 위한 맞춤형 정보를 알려드릴게요!
     </p>
 
-    <div class="mx-auto p-4 max-w-4xl">
+    <div class="mx-auto p-4">
       <p class="text-2xl font-bold mb-4 text-[28px] text-center">정책</p>
       <div class="flex border-t-4 border-darkBlue py-4"></div>
       <div v-if="policyList.length === 0" class="text-xl font-semibold">
         {{ memberName }}님의 조건에 해당하는 정책이 없습니다.
       </div>
-      <div
-        v-else
-        class="relative bg-white p-6 rounded-lg shadow-md max-w-xs w-full"
-      >
-        <div v-for="policy in policyList" :key="policy" :value="policy">
+      <div v-else class="flex justify-center gap-10 w-full">
+        <div
+          v-for="policy in policyList"
+          :key="policy"
+          :value="policy"
+          class="relative bg-white p-6 rounded-lg shadow-md max-w-sm w-full"
+        >
           <p class="text-2xl font-bold mb-4 text-center underline">
             {{ policy.name }}
           </p>

--- a/src/views/policy/PolicyDetailPage.vue
+++ b/src/views/policy/PolicyDetailPage.vue
@@ -1,9 +1,9 @@
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue';
-import { useRoute } from 'vue-router';
-import { usePolicyStore } from '@/stores/policy';
-import ShareButton from '@/components/kakao/ShareButton.vue';
-import UrlCopyIcon from '@/assets/url_copy.svg';
+import { ref, onMounted, onUnmounted } from "vue";
+import { useRoute } from "vue-router";
+import { usePolicyStore } from "@/stores/policy";
+import ShareButton from "@/components/kakao/ShareButton.vue";
+import UrlCopyIcon from "@/assets/url_copy.svg";
 
 const route = useRoute();
 const policyStore = usePolicyStore();
@@ -25,8 +25,9 @@ const formatDate = (date) => {
 };
 
 const copyUrl = () => {
-  navigator.clipboard.writeText(window.location.href)
-    .then(() => alert('URL이 복사되었습니다.'));
+  navigator.clipboard
+    .writeText(window.location.href)
+    .then(() => alert("URL이 복사되었습니다."));
 };
 
 onMounted(async () => {
@@ -35,14 +36,16 @@ onMounted(async () => {
     await policyStore.getPolicyInfo();
     await policyStore.getPolicyDetail(idx);
     policyDetail.value = policyStore.PolicyDetail;
-    policyListItem.value = policyStore.PolicyInfoList.find(item => item.idx === idx);
+    policyListItem.value = policyStore.PolicyInfoList.find(
+      (item) => item.idx === idx
+    );
     if (typeof window !== "undefined") {
       shareUrl.value = `${window.location.origin}/policy/detail/${policyDetail.value.idx}`;
     }
 
-    headerHeight.value = document.querySelector('header')?.offsetHeight || 0;
+    headerHeight.value = document.querySelector("header")?.offsetHeight || 0;
 
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener("scroll", handleScroll);
   } catch (error) {
     console.error("Error fetching policy data: ", error);
   } finally {
@@ -51,7 +54,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
-  window.removeEventListener('scroll', handleScroll);
+  window.removeEventListener("scroll", handleScroll);
 });
 
 const handleScroll = () => {
@@ -63,17 +66,17 @@ const handleScroll = () => {
 };
 
 const scrollToTop = () => {
-  const titleElement = document.querySelector('h2');
+  const titleElement = document.querySelector("h2");
   if (titleElement) {
-    titleElement.scrollIntoView({ behavior: 'smooth' });
-    activeSection.value = 'top';
+    titleElement.scrollIntoView({ behavior: "smooth" });
+    activeSection.value = "top";
   }
 };
 
 const scrollToSection = (sectionId) => {
   const section = document.getElementById(sectionId);
   if (section) {
-    section.scrollIntoView({ behavior: 'smooth' });
+    section.scrollIntoView({ behavior: "smooth" });
     activeSection.value = sectionId;
   }
 };
@@ -81,40 +84,54 @@ const scrollToSection = (sectionId) => {
 const formatPolicySubject = (text) => {
   if (!text) return "";
 
-  const segments = text.split(/[\u2022\u25E6\u25A1\*\u25CB](?!\d-\d)|(?<!\d)-(?=\D)/).filter(Boolean);
+  const segments = text
+    .split(/[\u2022\u25E6\u25A1\*\u25CB](?!\d-\d)|(?<!\d)-(?=\D)/)
+    .filter(Boolean);
 
   return segments
-    .map(segment => {
+    .map((segment) => {
       const subSegments = segment
-        .split(/(?<!\d)-(?=\D)|(?<=\D)-(?=\d)|(?=[가-힣]\.)|(?=※)|(?=\[.*?\])|(?=\b\d{1,2}\.(?!\d{1,2}\.\d{1,2})\b)/)
+        .split(
+          /(?<!\d)-(?=\D)|(?<=\D)-(?=\d)|(?=[가-힣]\.)|(?=※)|(?=\[.*?\])|(?=\b\d{1,2}\.(?!\d{1,2}\.\d{1,2})\b)/
+        )
         .filter(Boolean)
-        .map(sub => {
+        .map((sub) => {
           const trimmedSub = sub.trim();
 
           if (/^\d{4}\.\d{1,2}\.\d{1,2}$/.test(trimmedSub)) {
             return trimmedSub;
-          }
-          else if (/^[가-힣]\.|^※|^\[.*?\]|^- |\b\d{1,2}\.(?!\d)/.test(trimmedSub)) {
+          } else if (
+            /^[가-힣]\.|^※|^\[.*?\]|^- |\b\d{1,2}\.(?!\d)/.test(trimmedSub)
+          ) {
             return `<br>${trimmedSub}`;
           }
           return `- ${trimmedSub}`;
         });
 
-      return subSegments.join('');
+      return subSegments.join("");
     })
-    .join('<br><br>');
+    .join("<br><br>");
 };
-
 </script>
 
 <template>
   <div class="contentsWrap mw_wrap p-4">
     <!-- 제목 -->
     <div class="flex justify-between items-center mb-10">
-      <h2 id="page-title" class="text-3xl font-bold">{{ policyListItem?.name }}</h2>
+      <h2 id="page-title" class="text-3xl font-bold">
+        {{ policyListItem?.name }}
+      </h2>
       <div class="flex space-x-2">
-        <ShareButton :title="policyListItem?.name" :description="policyDetail?.subject" :shareUrl="shareUrl" class="w-6 h-6 bg-white rounded-full flex items-center justify-center" />
-        <button @click="copyUrl" class="w-6 h-6 bg-white rounded-full flex items-center justify-center border border-gray-300">
+        <ShareButton
+          :title="policyListItem?.name"
+          :description="policyDetail?.subject"
+          :shareUrl="shareUrl"
+          class="w-6 h-6 bg-white rounded-full flex items-center justify-center"
+        />
+        <button
+          @click="copyUrl"
+          class="w-6 h-6 bg-white rounded-full flex items-center justify-center border border-gray-300"
+        >
           <img :src="UrlCopyIcon" alt="URL 복사" class="w-6 h-6" />
         </button>
       </div>
@@ -125,7 +142,12 @@ const formatPolicySubject = (text) => {
       <!-- 왼쪽 콘텐츠 영역 (테이블) -->
       <div class="left w-full lg:w-3/4 lg:pr-6">
         <!-- 사업 개요 -->
-        <h3 id="business-overview" class="section-title border-b-2 border-gray-300 pb-2 mb-4">사업 개요</h3>
+        <h3
+          id="business-overview"
+          class="section-title border-b-2 border-gray-300 pb-2 mb-4"
+        >
+          사업 개요
+        </h3>
         <div class="content-section mb-10">
           <div class="content-row mb-4">
             <span class="title-cell">정책 유형</span>
@@ -138,7 +160,10 @@ const formatPolicySubject = (text) => {
           <div class="content-row mb-4">
             <span class="title-cell">정책 소개</span>
             <!-- v-html을 사용해 HTML 형식으로 텍스트를 렌더링 -->
-            <span class="content-cell" v-html="formatPolicySubject(policyDetail?.subject)"></span>
+            <span
+              class="content-cell"
+              v-html="formatPolicySubject(policyDetail?.subject)"
+            ></span>
           </div>
           <div class="content-row mb-4">
             <span class="title-cell">지원 내용</span>
@@ -146,7 +171,10 @@ const formatPolicySubject = (text) => {
           </div>
           <div class="content-row mb-4">
             <span class="title-cell">사업 운영 기간</span>
-            <span class="content-cell">{{ formatDate(policyListItem?.apply_start_date) }} ~ {{ formatDate(policyListItem?.apply_end_date) }}</span>
+            <span class="content-cell"
+              >{{ formatDate(policyListItem?.apply_start_date) }} ~
+              {{ formatDate(policyListItem?.apply_end_date) }}</span
+            >
           </div>
           <div class="content-row mb-4">
             <span class="title-cell">지원 규모</span>
@@ -155,17 +183,35 @@ const formatPolicySubject = (text) => {
           <div class="content-row mb-4">
             <span class="title-cell">관련 사이트</span>
             <span class="content-cell">
-              <a :href="policyDetail?.url" class="text-blue-500 underline" target="_blank">{{ policyDetail?.url }}</a>
+              <a
+                :href="policyDetail?.url"
+                class="text-blue-500 underline"
+                target="_blank"
+                >{{ policyDetail?.url }}</a
+              >
             </span>
           </div>
         </div>
 
         <!-- 신청 자격 -->
-        <h3 id="eligibility" class="section-title border-b-2 border-gray-300 pb-2 mb-4">신청 자격</h3>
+        <h3
+          id="eligibility"
+          class="section-title border-b-2 border-gray-300 pb-2 mb-4"
+        >
+          신청 자격
+        </h3>
         <div class="content-section mb-10">
           <div class="content-row mb-4">
             <span class="title-cell">조건</span>
             <span class="content-cell">{{ policyDetail?.condition }}</span>
+          </div>
+          <div class="content-row mb-4">
+            <span class="title-cell">나이</span>
+            <span class="content-cell">{{ policyDetail?.minAge }} ~ {{ policyDetail?.maxAge }}</span>
+          </div>
+          <div class="content-row mb-4">
+            <span class="title-cell">직업</span>
+            <span class="content-cell">{{ policyDetail?.job }}</span>
           </div>
           <div class="content-row mb-4">
             <span class="title-cell">자격</span>
@@ -174,29 +220,87 @@ const formatPolicySubject = (text) => {
         </div>
 
         <!-- 신청 방법 -->
-        <h3 id="application-method" class="section-title border-b-2 border-gray-300 pb-2 mb-4">신청 방법</h3>
+        <h3
+          id="application-method"
+          class="section-title border-b-2 border-gray-300 pb-2 mb-4"
+        >
+          신청 방법
+        </h3>
         <p class="py-3 px-4 mb-10">{{ policyDetail?.way }}</p>
 
         <!-- 제출 서류 -->
-        <h3 id="required-documents" class="section-title border-b-2 border-gray-300 pb-2 mb-4">제출 서류</h3>
+        <h3
+          id="required-documents"
+          class="section-title border-b-2 border-gray-300 pb-2 mb-4"
+        >
+          제출 서류
+        </h3>
         <ul class="list-disc pl-6 mb-10">
-          <li v-for="doc in policyDetail?.requiredDocuments" :key="doc">{{ doc }}</li>
+          <li v-for="doc in policyDetail?.requiredDocuments" :key="doc">
+            {{ doc }}
+          </li>
         </ul>
 
         <!-- 뒤로 가기 링크 -->
-        <router-link to="/" class="text-blue-500 mt-4 inline-block">뒤로 가기</router-link>
+        <router-link to="/" class="text-blue-500 mt-4 inline-block"
+          >뒤로 가기</router-link
+        >
       </div>
 
       <!-- 오른쪽 네비게이션 (모바일에서는 숨기기) -->
-      <div :class="['right-nav', { 'fixed': isFixed }]" :style="{ top: isFixed ? headerHeight + '500px' : 'auto' }">
+      <div
+        :class="['right-nav', { fixed: isFixed }]"
+        :style="{ top: isFixed ? headerHeight + '500px' : 'auto' }"
+      >
         <div class="aside border-l pl-4">
-          <p><a href="javascript:void(0)" @click="scrollToTop" :class="{'active-link': activeSection === 'top'}">이 페이지의 구성</a></p>
+          <p>
+            <a
+              href="javascript:void(0)"
+              @click="scrollToTop"
+              :class="{ 'active-link': activeSection === 'top' }"
+              >이 페이지의 구성</a
+            >
+          </p>
           <nav class="mt-4">
             <ul class="lnb space-y-2">
-              <li><a href="javascript:void(0)" @click="scrollToSection('business-overview')" :class="{'active-link': activeSection === 'business-overview'}">사업 개요</a></li>
-              <li><a href="javascript:void(0)" @click="scrollToSection('eligibility')" :class="{'active-link': activeSection === 'eligibility'}">신청 자격</a></li>
-              <li><a href="javascript:void(0)" @click="scrollToSection('application-method')" :class="{'active-link': activeSection === 'application-method'}">신청 방법</a></li>
-              <li><a href="javascript:void(0)" @click="scrollToSection('required-documents')" :class="{'active-link': activeSection === 'required-documents'}">제출 서류</a></li>
+              <li>
+                <a
+                  href="javascript:void(0)"
+                  @click="scrollToSection('business-overview')"
+                  :class="{
+                    'active-link': activeSection === 'business-overview',
+                  }"
+                  >사업 개요</a
+                >
+              </li>
+              <li>
+                <a
+                  href="javascript:void(0)"
+                  @click="scrollToSection('eligibility')"
+                  :class="{ 'active-link': activeSection === 'eligibility' }"
+                  >신청 자격</a
+                >
+              </li>
+              <li>
+                <a
+                  href="javascript:void(0)"
+                  @click="scrollToSection('application-method')"
+                  :class="{
+                    'active-link': activeSection === 'application-method',
+                  }"
+                  >신청 방법</a
+                >
+              </li>
+              <li>
+                <a
+                  href="javascript:void(0)"
+                  @click="scrollToSection('required-documents')"
+                  :class="{
+                    'active-link': activeSection === 'required-documents',
+                  }"
+                  >제출 서류</a
+                >
+              </li>
             </ul>
           </nav>
         </div>
@@ -266,7 +370,7 @@ const formatPolicySubject = (text) => {
 
 .right-nav a:hover,
 .right-nav a.active-link {
-  color: #0E429D;
+  color: #0e429d;
 }
 
 @media (max-width: 640px) {

--- a/src/views/policy/PolicyRecommandPage.vue
+++ b/src/views/policy/PolicyRecommandPage.vue
@@ -20,14 +20,12 @@ const totalPages = computed(() =>
   Math.ceil(policyList.value.length / itemsPerPage)
 );
 
-// 현재 그룹에 표시할 페이지 번호 목록 (5개씩)
 const visiblePages = computed(() => {
   const start = pageGroup.value * 5 + 1;
   const end = Math.min(start + 4, totalPages.value);
   return Array.from({ length: end - start + 1 }, (_, i) => start + i);
 });
 
-// 페이지 이동
 const changePage = (page) => {
   if (page > 0 && page <= totalPages.value) {
     currentPage.value = page;
@@ -35,7 +33,6 @@ const changePage = (page) => {
   }
 };
 
-// 페이지 그룹 변경
 const nextPageGroup = () => {
   if (pageGroup.value < Math.floor(totalPages.value / 5)) {
     pageGroup.value++;
@@ -162,14 +159,23 @@ onMounted(() => {
     applyFilters();
   }
 });
+
+const updateFilters = (filters) => {
+  selectedCity.value = filters.selectedCity;
+  district.value = filters.district;
+  selectedPolicyType.value = filters.selectedPolicyType;
+  selectedAge.value = filters.selectedAge;
+  selectedJob.value = filters.selectedJob;
+  selectedName.value = filters.selectedName;
+};
 </script>
 
 <template>
   <section
-    class="bg-gray-800 text-white p-4 rounded-lg mt-6 flex mx-auto flex-col items-center gap-4 md:gap-2 shadow-md w-[90%] md:flex-row md:flex-wrap md:justify-center"
+    class="bg-gray-800 text-white p-4 rounded-lg mt-6 flex mx-auto flex-col items-center gap-4 md:gap-2 shadow-md w-[90%] md:flex-row md:flex-wrap md:justify-center max-w-8xl w-full"
   >
     <div
-      class="flex items-center space-x-2 bg-[#002842] text-white px-3 py-2 rounded-lg md:rounded-l-lg w-full md:w-auto"
+      class="flex items-center space-x-2 bg-darkBlue text-white px-3 py-2 rounded-lg md:rounded-l-lg w-full md:w-auto"
     >
       <i class="fas fa-users"></i>
       <strong class="text-lg font-semibold">정책 검색</strong>
@@ -267,14 +273,14 @@ onMounted(() => {
 
     <button
       @click="applyFilters"
-      class="bg-[#002842] px-4 py-2 rounded-lg w-full md:w-auto flex items-center justify-center"
+      class="bg-darkBlue px-4 py-2 rounded-lg w-full md:w-auto flex items-center justify-center"
     >
       <i class="fas fa-search"></i>
       <span class="ml-1">검색</span>
     </button>
   </section>
 
-  <div class="mx-auto p-4 max-w-4xl">
+  <div class="mx-auto p-4 w-full max-w-8xl">
     <p class="text-2xl font-bold mb-4 text-[32px]">검색한 정책</p>
     <div class="flex border-t-4 border-darkBlue py-4"></div>
 
@@ -287,7 +293,7 @@ onMounted(() => {
         v-else
         v-for="(policy, index) in paginatedPolicies"
         :key="index"
-        class="hover:bg-gray-100 cursor-pointer flex items-center space-x-4 border-t border-gray-200 p-2"
+        class="hover:bg-gray-100 cursor-pointer flex items-center space-x-10 border-t border-gray-200 p-2"
         @click="
           $router.push({
             name: 'PolicyDetail',

--- a/src/views/policy/PolicyRecommandPage.vue
+++ b/src/views/policy/PolicyRecommandPage.vue
@@ -143,7 +143,13 @@ onMounted(() => {
   selectedName.value = localStorage.getItem("selectedName") || "";
 
   const savedPage = localStorage.getItem("page");
-  currentPage.value = savedPage ? parseInt(savedPage, 10) : 1;
+  if (savedPage) {
+    currentPage.value = parseInt(savedPage, 10);
+    pageGroup.value = Math.floor((currentPage.value - 1) / 5);
+  } else {
+    currentPage.value = 1;
+    pageGroup.value = 0;
+  }
 
   if (
     selectedCity.value ||


### PR DESCRIPTION
### #️⃣ 24.11.16

### 📝 작업 내용
[나만의 서비스]
- 백엔드와 연동 후 맞춤형 정책 추천 기능 구현
- 정책 추천 UI 구현

[정책 페이지]
- 정책 페이지네이션 새로고침 시 유지
- 필터링 전 기본으로 모든 정책 보여주도록 구현
- 정책 상세보기에 나이, 직업 추가
- 정책 UI 수정
- 
### 스크린샷
1. 정책 상세보기에 나이, 직업 추가
<img width="471" alt="image" src="https://github.com/user-attachments/assets/c3e56e75-c2e8-4569-8130-ba0d261783b0">

2. 맞춤형 정책 추천
<img width="775" alt="image" src="https://github.com/user-attachments/assets/a3840e2b-d266-4517-9098-e22422c99368">



