### PR TITLE
Fix: 정책, 정책 상세보기, 나만의 서비스 코드 & UI 전체 수정

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,12 +2,31 @@
 import { RouterLink, RouterView } from "vue-router";
 import DefaultLayout from "./components/layouts/DefaultLayout.vue";
 
-import { onMounted } from 'vue';
-import { useAuthStore } from '@/stores/auth';
+import { onMounted } from "vue";
+import { useAuthStore } from "@/stores/auth";
 
 const authStore = useAuthStore();
 
+function initializeLocalStorage() {
+  const defaults = {
+    selectedCity: null,
+    district: "",
+    selectedPolicyType: null,
+    selectedAge: "",
+    selectedJob: null,
+    selectedName: "",
+    page: 1,
+  };
+
+  Object.entries(defaults).forEach(([key, value]) => {
+    if (localStorage.getItem(key) === null) {
+      localStorage.setItem(key, JSON.stringify(value));
+    }
+  });
+}
+
 onMounted(() => {
+  initializeLocalStorage();
   authStore.initializeMemberFromToken();
 });
 </script>
@@ -19,7 +38,6 @@ onMounted(() => {
 </template>
 
 <style scoped>
-
 @media (min-width: 1024px) {
   header {
     display: flex;

--- a/src/components/home/FilterSection.vue
+++ b/src/components/home/FilterSection.vue
@@ -119,7 +119,6 @@ onMounted(() => {
     <div
       class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
     >
-      <i class="fas fa-map-marker-alt text-gray-500"></i>
       <select
         v-model="selectedCity"
         class="bg-transparent w-full focus:outline-none"
@@ -134,7 +133,6 @@ onMounted(() => {
     <div
       class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
     >
-      <i class="fa-solid fa-location-arrow text-gray-500"></i>
       <input
         v-model="district"
         id="district"
@@ -147,7 +145,6 @@ onMounted(() => {
     <div
       class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
     >
-      <i class="fas fa-briefcase text-gray-500"></i>
       <select
         v-model="selectedJob"
         class="bg-transparent w-full focus:outline-none"
@@ -168,7 +165,6 @@ onMounted(() => {
     <div
       class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
     >
-      <i class="fas fa-user text-gray-500"></i>
       <input
         v-model="selectedAge"
         id="selectedAge"
@@ -181,7 +177,6 @@ onMounted(() => {
     <div
       class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
     >
-      <i class="fa-solid fa-check text-gray-500"></i>
       <select
         v-model="selectedPolicyType"
         class="bg-transparent w-full focus:outline-none"
@@ -196,7 +191,6 @@ onMounted(() => {
     <div
       class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
     >
-      <i class="fas fa-search"></i>
       <input
         v-model="selectedName"
         id="selectedName"
@@ -210,7 +204,6 @@ onMounted(() => {
       @click="applyFilters"
       class="bg-darkBlue px-4 py-2 rounded-lg w-full md:w-auto flex items-center justify-center"
     >
-      <i class="fas fa-search"></i>
       <span class="ml-1">검색</span>
     </button>
   </section>

--- a/src/components/home/FilterSection.vue
+++ b/src/components/home/FilterSection.vue
@@ -1,122 +1,218 @@
 <script setup>
-import { ref } from 'vue';
-import { usePolicyStore } from '@/stores/policy';
-import { library } from '@fortawesome/fontawesome-svg-core';
-import '@fortawesome/fontawesome-free/css/all.css';
-import '@fortawesome/fontawesome-free/js/all.js';
-import { faMapMarkerAlt, faBriefcase, faUser, faMoneyBillWave, faSearch } from '@fortawesome/free-solid-svg-icons';
-
-library.add(faMapMarkerAlt, faBriefcase, faUser, faMoneyBillWave, faSearch);
-
-const userData = ref({
-    region: '',
-    job: '',
-    ageRange: '',
-    income: '',
-    policyName: '',
-});
-
-const emit = defineEmits(['filterChanged']);
+import { usePolicyStore } from "@/stores/policy.js";
+import { ref, onMounted } from "vue";
 
 const policyStore = usePolicyStore();
 
-const getRecommendations = async () => {
-    try {
-        const filteredPolicies = policyStore.filterPolicies(userData.value);
-        emit('filterChanged', filteredPolicies);
-    } catch (error) {
-        console.error("추천 정책 오류", error);
-    }
+const selectedCity = ref(null);
+const district = ref(null);
+const selectedPolicyType = ref(null);
+const selectedAge = ref(null);
+const selectedJob = ref(null);
+const selectedName = ref(null);
+
+const cities = [
+  "서울",
+  "부산",
+  "대구",
+  "인천",
+  "광주",
+  "대전",
+  "울산",
+  "세종",
+  "경기",
+  "강원",
+  "충북",
+  "충남",
+  "전북",
+  "전남",
+  "경상북도",
+  "경남",
+  "제주",
+];
+const policyTypes = [
+  "일자리(창업)",
+  "일자리(취업)",
+  "건강",
+  "교육",
+  "금융",
+  "문화",
+  "복지",
+  "주거비 지원",
+  "주택공급",
+  "참여",
+];
+
+const applyFilters = async () => {
+  localStorage.setItem("selectedCity", selectedCity.value);
+  localStorage.setItem("district", district.value);
+  localStorage.setItem("selectedPolicyType", selectedPolicyType.value);
+  localStorage.setItem("selectedAge", selectedAge.value);
+  localStorage.setItem("selectedJob", selectedJob.value);
+  localStorage.setItem("selectedName", selectedName.value);
+
+  policyStore.filterCondition.city =
+    selectedCity.value === "전체" || selectedCity.value === "null"
+      ? null
+      : selectedCity.value;
+
+  policyStore.filterCondition.district =
+    district.value === "" || district.value === "null" ? null : district.value;
+
+  policyStore.filterCondition.type =
+    selectedPolicyType.value === "전체" || selectedPolicyType.value === "null"
+      ? null
+      : selectedPolicyType.value;
+
+  policyStore.filterCondition.age =
+    selectedAge.value === "" || selectedAge.value === "null"
+      ? null
+      : selectedAge.value;
+
+  policyStore.filterCondition.job =
+    selectedJob.value === "전체" || selectedJob.value === "null"
+      ? null
+      : selectedJob.value;
+
+  policyStore.filterCondition.name =
+    selectedName.value === "" || selectedName.value === "null"
+      ? null
+      : selectedName.value;
+
+  await policyStore.getPolicyFilter();
+
+  const filterEvent = new CustomEvent("filters-applied");
+  window.dispatchEvent(filterEvent);
 };
+
+onMounted(() => {
+  selectedCity.value = localStorage.getItem("selectedCity") || null;
+  district.value = localStorage.getItem("district") || "";
+  selectedPolicyType.value = localStorage.getItem("selectedPolicyType") || null;
+  selectedAge.value = localStorage.getItem("selectedAge") || "";
+  selectedJob.value = localStorage.getItem("selectedJob") || null;
+  selectedName.value = localStorage.getItem("selectedName") || "";
+
+  if (
+    selectedCity.value ||
+    district.value ||
+    selectedPolicyType.value ||
+    selectedAge.value ||
+    selectedJob.value ||
+    selectedName.value
+  ) {
+    applyFilters();
+    }
+});
 </script>
 
-
-
 <template>
-    <section class="bg-gray-800 text-white p-4 rounded-lg mt-6 flex flex-col items-center gap-4 md:gap-2 shadow-md w-full md:flex-row md:flex-wrap md:justify-center">
-        <!-- Title -->
-        <div class="flex items-center space-x-2 bg-[#002842] text-white px-3 py-2 rounded-lg md:rounded-l-lg w-full md:w-auto">
-            <i class="fas fa-users"></i>
-            <strong class="text-lg font-semibold">통합 정책 검색</strong>
-        </div>
+  <section
+    class="text-white p-4 rounded-lg mt-6 flex mx-auto flex-col items-center gap-4 md:gap-2 w-[90%] md:flex-row md:flex-wrap md:justify-center"
+  >
+    <div
+      class="flex items-center space-x-2 bg-[#002842] text-white px-4 py-3 rounded-lg md:rounded-l-lg w-full md:w-auto"
+    >
+      <i class="fas fa-users"></i>
+      <strong class="text-lg font-semibold">정책 검색</strong>
+    </div>
 
-        <!-- 지역 필터 -->
-        <div class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto">
-            <i class="fas fa-map-marker-alt text-gray-500"></i>
-            <select v-model="userData.region" id="region" class="bg-transparent w-full focus:outline-none">
-                <option value="">지역</option>
-                <option value="서울">서울</option>
-                <option value="경기">경기</option>
-                <option value="부산">부산</option>
-                <option value="인천">인천</option>
-                <option value="대전">대전</option>
-                <option value="대구">대구</option>
-                <option value="광주">광주</option>
-                <option value="울산">울산</option>
-                <option value="세종">세종</option>
-                <option value="강원">강원</option>
-                <option value="충북">충북</option>
-                <option value="충남">충남</option>
-                <option value="전북">전북</option>
-                <option value="전남">전남</option>
-                <option value="경북">경북</option>
-                <option value="경남">경남</option>
-                <option value="제주">제주</option>
-            </select>
-        </div>
+    <div
+      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
+    >
+      <i class="fas fa-map-marker-alt text-gray-500"></i>
+      <select
+        v-model="selectedCity"
+        class="bg-transparent w-full focus:outline-none"
+      >
+        <option value="null">전체</option>
+        <option v-for="city in cities" :key="city" :value="city">
+          {{ city }}
+        </option>
+      </select>
+    </div>
 
-        <!-- 직업 필터 -->
-        <div class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto">
-            <i class="fas fa-briefcase text-gray-500"></i>
-            <select v-model="userData.job" id="job" class="bg-transparent w-full focus:outline-none">
-                <option value="">직업</option>
-                <option value="학생">학생</option>
-                <option value="무직">무직</option>
-                <option value="직장인">직장인</option>
-                <option value="자영업">자영업</option>
-                <option value="프리랜서">프리랜서</option>
-                <option value="(예비)창업자">(예비)창업자</option>
-                <option value="일용근로자">일용근로자</option>
-                <option value="단기근로자">단기근로자</option>
-                <option value="영농종사자">영농종사자</option>
-            </select>
-        </div>
+    <div
+      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
+    >
+      <i class="fa-solid fa-location-arrow text-gray-500"></i>
+      <input
+        v-model="district"
+        id="district"
+        type="text"
+        placeholder="지역구를 입력해 주세요."
+        class="bg-transparent w-full focus:outline-none"
+      />
+    </div>
 
-        <!-- 연령 필터 -->
-        <div class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto">
-            <i class="fas fa-user text-gray-500"></i>
-            <select v-model="userData.ageRange" id="ageRange" class="bg-transparent w-full focus:outline-none">
-                <option value="">연령</option>
-                <option value="19-24">19~24</option>
-                <option value="25-29">25~29</option>
-                <option value="30-34">30~34</option>
-                <option value="35-39">35~39</option>
-                <option value="40">40세 이상</option>
-            </select>
-        </div>
+    <div
+      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
+    >
+      <i class="fas fa-briefcase text-gray-500"></i>
+      <select
+        v-model="selectedJob"
+        class="bg-transparent w-full focus:outline-none"
+      >
+        <option value="null">전체</option>
+        <option value="학생">학생</option>
+        <option value="무직">무직</option>
+        <option value="직장인">직장인</option>
+        <option value="자영업">자영업</option>
+        <option value="프리랜서">프리랜서</option>
+        <option value="(예비)창업자">(예비)창업자</option>
+        <option value="일용근로자">일용근로자</option>
+        <option value="단기근로자">단기근로자</option>
+        <option value="영농종사자">영농종사자</option>
+      </select>
+    </div>
 
-        <!-- 소득 수준 필터 -->
-        <div class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto">
-            <i class="fas fa-money-bill-wave text-gray-500"></i>
-            <select v-model="userData.income" id="income" class="bg-transparent w-full focus:outline-none">
-                <option value="">소득</option>
-                <option value="저소득">저소득</option>
-                <option value="중소득">중소득</option>
-                <option value="고소득">고소득</option>
-            </select>
-        </div>
+    <div
+      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
+    >
+      <i class="fas fa-user text-gray-500"></i>
+      <input
+        v-model="selectedAge"
+        id="selectedAge"
+        type="text"
+        placeholder="나이를 입력해 주세요."
+        class="bg-transparent w-full focus:outline-none"
+      />
+    </div>
 
-        <!-- 정책명 검색 필터 -->
-        <div class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md flex-1 w-full">
-            <i class="fas fa-search text-gray-500"></i>
-            <input v-model="userData.policyName" type="text" id="policyName" placeholder="정책명을 입력해주세요." class="bg-transparent w-full focus:outline-none">
-        </div>
+    <div
+      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
+    >
+      <i class="fa-solid fa-check text-gray-500"></i>
+      <select
+        v-model="selectedPolicyType"
+        class="bg-transparent w-full focus:outline-none"
+      >
+        <option value="null">전체</option>
+        <option v-for="type in policyTypes" :key="type" :value="type">
+          {{ type }}
+        </option>
+      </select>
+    </div>
 
-        <!-- 검색 버튼 -->
-        <button @click="getRecommendations" class="bg-[#002842] px-4 py-2 rounded-lg w-full md:w-auto flex items-center justify-center">
-            <i class="fas fa-search"></i>
-            <span class="ml-1">검색</span>
-        </button>
-    </section>
+    <div
+      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
+    >
+      <i class="fas fa-search"></i>
+      <input
+        v-model="selectedName"
+        id="selectedName"
+        type="text"
+        placeholder="정책명을 입력해 주세요."
+        class="bg-transparent w-full focus:outline-none"
+      />
+    </div>
+
+    <button
+      @click="applyFilters"
+      class="bg-darkBlue px-4 py-2 rounded-lg w-full md:w-auto flex items-center justify-center"
+    >
+      <i class="fas fa-search"></i>
+      <span class="ml-1">검색</span>
+    </button>
+  </section>
 </template>
-

--- a/src/components/home/FilterSection.vue
+++ b/src/components/home/FilterSection.vue
@@ -102,7 +102,7 @@ onMounted(() => {
     selectedName.value
   ) {
     applyFilters();
-    }
+  }
 });
 </script>
 
@@ -113,7 +113,6 @@ onMounted(() => {
     <div
       class="flex items-center space-x-2 bg-[#002842] text-white px-4 py-3 rounded-lg md:rounded-l-lg w-full md:w-auto"
     >
-      <i class="fas fa-users"></i>
       <strong class="text-lg font-semibold">정책 검색</strong>
     </div>
 

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -166,6 +166,13 @@ export const useAuthStore = defineStore("auth", {
       localStorage.removeItem("selectedJob");
       localStorage.removeItem("selectedName");
       localStorage.removeItem("page");
+
+      localStorage.setItem("selectedCity", null);
+      localStorage.setItem("district", "");
+      localStorage.setItem("selectedPolicyType", null);
+      localStorage.setItem("selectedAge", "");
+      localStorage.setItem("selectedJob", null);
+      localStorage.setItem("selectedName", "");
       delete axiosInstance.defaults.headers.common["Authorization"];
     },
   },

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -36,7 +36,7 @@ const handleFilterChanged = (policies) => {
 <style scoped>
 .homepage {
   padding: 1rem;
-  max-width: 1200px;
+  max-width: 1350px;
   margin: 0 auto;
 }
 

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -1,11 +1,11 @@
 <script setup>
-import { ref } from 'vue';
-import FilterSection from '@/components/home/FilterSection.vue';
-import FilterResult from '@/components/home/FilterResult.vue'; 
-import PolicySection from '@/components/home/PolicySection.vue';
-import SubscriptionSection from '@/components/home/SubscriptionSection.vue';
-import FinanceSection from '@/components//home/FinanceSection.vue';
-import BannerSlider from '@/components/home/BannerSlider.vue';
+import { ref } from "vue";
+import FilterSection from "@/components/home/FilterSection.vue";
+import FilterResult from "@/components/home/FilterResult.vue";
+import PolicySection from "@/components/home/PolicySection.vue";
+import SubscriptionSection from "@/components/home/SubscriptionSection.vue";
+import FinanceSection from "@/components//home/FinanceSection.vue";
+import BannerSlider from "@/components/home/BannerSlider.vue";
 
 const filteredPolicies = ref([]);
 const searchExecuted = ref(false);
@@ -22,13 +22,16 @@ const handleFilterChanged = (policies) => {
   </div>
   <div class="homepage container mx-auto p-4">
     <FilterSection @filterChanged="handleFilterChanged" class="mb-20" />
-    <FilterResult v-if="searchExecuted" :filteredPolicies="filteredPolicies" class="mb-20" />
+    <FilterResult
+      v-if="searchExecuted"
+      :filteredPolicies="filteredPolicies"
+      class="mb-20"
+    />
     <PolicySection class="mb-20" />
     <SubscriptionSection class="mb-20" />
     <FinanceSection class="mb-20" />
   </div>
 </template>
-
 
 <style scoped>
 .homepage {

--- a/src/views/auth/MyService.vue
+++ b/src/views/auth/MyService.vue
@@ -12,6 +12,8 @@ const policyStore = usePolicyStore();
 const subscriptionStore = useSubscriptionStore();
 const authStore = useAuthStore();
 
+const token = authStore.token;
+const isLogin = ref(!!token);
 const policyList = ref([]);
 const subscriptionList = ref([]);
 const filterSavings = ref([]);
@@ -112,6 +114,10 @@ const fetchLoan = async () => {
 };
 
 onMounted(async () => {
+  if (!token) {
+    isLogin.value = false;
+    return;
+  }
   await fetchPolicy();
   await fetchSubscription();
   await fetchSavings();
@@ -122,274 +128,297 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div
-    v-if="hasValuesInMyPageInfo"
-    class="flex flex-col items-center space-y-4"
-  >
-    <p class="text-3xl font-semibold text-gray-800 text-center mt-2 mb-2">
-      <span
-        class="shake text-3xl font-semibold text-gray-800 text-center mt-2 mb-2"
-        >{{ memberName }}</span
-      >
-      님을 위한 맞춤형 정보를 알려드릴게요!
-    </p>
-
-    <div class="mx-auto p-4">
-      <p class="text-2xl font-bold mb-4 text-[28px] text-center">정책</p>
-      <div class="flex border-t-4 border-darkBlue py-4"></div>
-      <div v-if="policyList.length === 0" class="text-xl font-semibold">
-        {{ memberName }}님의 조건에 해당하는 정책이 없습니다.
-      </div>
-      <div v-else class="flex justify-center gap-10 w-full">
-        <div
-          v-for="policy in policyList"
-          :key="policy"
-          :value="policy"
-          class="relative bg-white p-6 rounded-lg shadow-md max-w-sm w-full"
+  <div v-if="isLogin">
+    <div
+      v-if="hasValuesInMyPageInfo"
+      class="flex flex-col items-center space-y-4"
+    >
+      <p class="text-3xl font-semibold text-gray-800 text-center mt-2 mb-2">
+        <span
+          class="shake text-3xl font-semibold text-gray-800 text-center mt-2 mb-2"
+          >{{ memberName }}</span
         >
-          <p class="text-2xl font-bold mb-4 text-center underline">
-            {{ policy.name }}
-          </p>
-          <p class="text-xl mb-4 text-center font-semibold">
-            {{ policy.type }}
-          </p>
-          <p class="text-xl mb-4 text-center">
-            {{ formatDate(policy.startDate) }} ~
-            {{ formatDate(policy.endDate) }}
-          </p>
+        님을 위한 맞춤형 정보를 알려드릴게요!
+      </p>
+
+      <div class="mx-auto p-4">
+        <p class="text-2xl font-bold mb-4 text-[28px] text-center">정책</p>
+        <div class="flex border-t-4 border-darkBlue py-4"></div>
+        <div v-if="policyList.length === 0" class="text-xl font-semibold">
+          {{ memberName }}님의 조건에 해당하는 정책이 없습니다.
         </div>
-      </div>
-    </div>
-
-    <div class="mx-auto p-4 max-w-4xl">
-      <p class="text-2xl font-bold mb-4 text-[28px] text-center">청약</p>
-      <div class="flex border-t-4 border-darkBlue py-4"></div>
-      <div v-if="subscriptionList.length === 0" class="text-xl font-semibold">
-        {{ memberName }}님의 조건에 해당하는 청약이 없습니다.
-      </div>
-      <div v-else class="flex justify-center gap-10">
-        <div
-          v-for="subscription in subscriptionList"
-          :key="subscription"
-          :value="subscription"
-          class="relative bg-white p-6 rounded-lg shadow-md max-w-lg w-full text-center"
-        >
-          <p class="text-2xl font-bold mb-4 text-center underline">
-            {{ subscription.name }}
-          </p>
-          <p class="text-lg mb-4 text-center font-semibold">
-            {{ subscription.region }} {{ subscription.city }}
-          </p>
-          <p class="text-lg mb-4 text-center font-semibold">
-            {{ subscription.district }} {{ subscription.detail }}
-          </p>
-          <p class="text-lg mb-4 text-center">
-            {{ subscription.rentSecd }}
-          </p>
-          <p class="text-lg mb-4 text-center">
-            {{ subscription.houseDtlSecdNm }} / {{ subscription.houseDtlSecd }}
-          </p>
-          <p class="text-lg text-gray-600 mb-3 font-semibold underline">
-            {{ formatDate(subscription.rceptBgnde) }} ~
-            {{ formatDate(subscription.rceptEndde) }}
-          </p>
-          <p class="text-base text-right font-semibold">
-            <a
-              :href="subscription.pblancUrl"
-              class="text-blue-500 underline"
-              target="_blank"
-              rel="noopener noreferrer"
-              >상세 정보</a
-            >
-          </p>
-        </div>
-      </div>
-    </div>
-
-    <div class="mx-auto p-4 max-w-4xl">
-      <p class="text-2xl font-bold mb-4 text-[28px] text-center">금융</p>
-      <div class="flex border-t-4 border-darkBlue py-4"></div>
-
-      <div class="flex justify-center space-x-10 text-center">
-        <div class="relative bg-white p-6 rounded-lg shadow-md max-w-xs w-full">
-          <span
-            class="absolute top-0 left-4 -translate-y-1/2 bg-lightBlue text-black text-s font-semibold px-2 py-1 rounded-md"
+        <div v-else class="flex justify-center gap-10 w-full">
+          <div
+            v-for="policy in policyList"
+            :key="policy"
+            :value="policy"
+            class="relative bg-white p-6 rounded-lg shadow-md max-w-sm w-full"
           >
-            예금 BEST
-          </span>
-          <p class="text-xl font-bold mb-4 text-center">
-            {{ filterSavings.finPrdtNm }}
-          </p>
-          <div>
-            <img
-              src="@/assets/bank/부산은행.png"
-              alt="부산은행 로고"
-              class="w-28 h-auto mx-auto mb-4"
-            />
+            <p class="text-2xl font-bold mb-4 text-center underline">
+              {{ policy.name }}
+            </p>
+            <p class="text-xl mb-4 text-center font-semibold">
+              {{ policy.type }}
+            </p>
+            <p class="text-xl mb-4 text-center">
+              {{ formatDate(policy.startDate) }} ~
+              {{ formatDate(policy.endDate) }}
+            </p>
           </div>
-          <p class="text-gray-600 mb-3">
-            가입 가능 대상 : {{ filterSavings.joinMember }}
-          </p>
-          <p class="text-gray-600 mb-3">
-            가입 방법 : {{ filterSavings.joinWay }}
-          </p>
-          <p class="text-gray-600 mb-3">
-            {{ filterSavings.intrRateNm }} /
-            <span> {{ filterSavings.saveTrm }} 개월 </span>
-          </p>
-          <p class="text-gray-600 font-bold underline">
-            최대 연 {{ filterSavings.intrRate2 }}%
-          </p>
         </div>
+      </div>
 
-        <div
-          class="relative bg-white p-6 rounded-lg shadow-md max-w-xs w-full text-center"
-        >
-          <span
-            class="absolute top-0 left-4 -translate-y-1/2 bg-lightBlue text-black text-s font-semibold px-2 py-1 rounded-md"
+      <div class="mx-auto p-4 max-w-4xl">
+        <p class="text-2xl font-bold mb-4 text-[28px] text-center">청약</p>
+        <div class="flex border-t-4 border-darkBlue py-4"></div>
+        <div v-if="subscriptionList.length === 0" class="text-xl font-semibold">
+          {{ memberName }}님의 조건에 해당하는 청약이 없습니다.
+        </div>
+        <div v-else class="flex justify-center gap-10">
+          <div
+            v-for="subscription in subscriptionList"
+            :key="subscription"
+            :value="subscription"
+            class="relative bg-white p-6 rounded-lg shadow-md max-w-lg w-full text-center"
           >
-            대출 BEST
-          </span>
+            <p class="text-2xl font-bold mb-4 text-center underline">
+              {{ subscription.name }}
+            </p>
+            <p class="text-lg mb-4 text-center font-semibold">
+              {{ subscription.region }} {{ subscription.city }}
+            </p>
+            <p class="text-lg mb-4 text-center font-semibold">
+              {{ subscription.district }} {{ subscription.detail }}
+            </p>
+            <p class="text-lg mb-4 text-center">
+              {{ subscription.rentSecd }}
+            </p>
+            <p class="text-lg mb-4 text-center">
+              {{ subscription.houseDtlSecdNm }} /
+              {{ subscription.houseDtlSecd }}
+            </p>
+            <p class="text-lg text-gray-600 mb-3 font-semibold underline">
+              {{ formatDate(subscription.rceptBgnde) }} ~
+              {{ formatDate(subscription.rceptEndde) }}
+            </p>
+            <p class="text-base text-right font-semibold">
+              <a
+                :href="subscription.pblancUrl"
+                class="text-blue-500 underline"
+                target="_blank"
+                rel="noopener noreferrer"
+                >상세 정보</a
+              >
+            </p>
+          </div>
+        </div>
+      </div>
 
-          <p class="text-xl font-bold mb-4 text-center">
-            {{ filterLoan.korCoNm }}
-          </p>
-          <p class="text-gray-600 font-semibold mb-3">
-            {{ filterLoan.finPrdtNm }}
-          </p>
-          <p class="text-gray-600 mb-3">가입 방법 : {{ filterLoan.joinWay }}</p>
-          <p class="text-gray-600 mb-3">한도 : {{ filterLoan.loanLmt }}</p>
-          <p v-if="filterLoan.mrtgTypeNm" class="text-gray-600 mb-3">
-            담보 유형 : {{ filterLoan.mrtgTypeNm }}
-          </p>
-          <p class="text-gray-600 mb-3">
-            {{ filterLoan.lendRateTypeNm }}
-            <span> / {{ filterLoan.rpayTypeNm }} </span>
-          </p>
-          <p class="text-gray-600 font-bold underline">
-            최저 연 {{ filterLoan.lendRateMin }}%
-            <span class="text-gray-600 font-bold underline">
-              ~ 최고 연 {{ filterLoan.lendRateMax }}%
+      <div class="mx-auto p-4 max-w-4xl">
+        <p class="text-2xl font-bold mb-4 text-[28px] text-center">금융</p>
+        <div class="flex border-t-4 border-darkBlue py-4"></div>
+
+        <div class="flex justify-center space-x-10 text-center">
+          <div
+            class="relative bg-white p-6 rounded-lg shadow-md max-w-xs w-full"
+          >
+            <span
+              class="absolute top-0 left-4 -translate-y-1/2 bg-lightBlue text-black text-s font-semibold px-2 py-1 rounded-md"
+            >
+              예금 BEST
             </span>
-          </p>
+            <p class="text-xl font-bold mb-4 text-center">
+              {{ filterSavings.finPrdtNm }}
+            </p>
+            <div>
+              <img
+                src="@/assets/bank/부산은행.png"
+                alt="부산은행 로고"
+                class="w-28 h-auto mx-auto mb-4"
+              />
+            </div>
+            <p class="text-gray-600 mb-3">
+              가입 가능 대상 : {{ filterSavings.joinMember }}
+            </p>
+            <p class="text-gray-600 mb-3">
+              가입 방법 : {{ filterSavings.joinWay }}
+            </p>
+            <p class="text-gray-600 mb-3">
+              {{ filterSavings.intrRateNm }} /
+              <span> {{ filterSavings.saveTrm }} 개월 </span>
+            </p>
+            <p class="text-gray-600 font-bold underline">
+              최대 연 {{ filterSavings.intrRate2 }}%
+            </p>
+          </div>
+
+          <div
+            class="relative bg-white p-6 rounded-lg shadow-md max-w-xs w-full text-center"
+          >
+            <span
+              class="absolute top-0 left-4 -translate-y-1/2 bg-lightBlue text-black text-s font-semibold px-2 py-1 rounded-md"
+            >
+              대출 BEST
+            </span>
+
+            <p class="text-xl font-bold mb-4 text-center">
+              {{ filterLoan.korCoNm }}
+            </p>
+            <p class="text-gray-600 font-semibold mb-3">
+              {{ filterLoan.finPrdtNm }}
+            </p>
+            <p class="text-gray-600 mb-3">
+              가입 방법 : {{ filterLoan.joinWay }}
+            </p>
+            <p class="text-gray-600 mb-3">한도 : {{ filterLoan.loanLmt }}</p>
+            <p v-if="filterLoan.mrtgTypeNm" class="text-gray-600 mb-3">
+              담보 유형 : {{ filterLoan.mrtgTypeNm }}
+            </p>
+            <p class="text-gray-600 mb-3">
+              {{ filterLoan.lendRateTypeNm }}
+              <span> / {{ filterLoan.rpayTypeNm }} </span>
+            </p>
+            <p class="text-gray-600 font-bold underline">
+              최저 연 {{ filterLoan.lendRateMin }}%
+              <span class="text-gray-600 font-bold underline">
+                ~ 최고 연 {{ filterLoan.lendRateMax }}%
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-else>
+      <p class="text-2xl font-semibold text-gray-800 text-center mb-10 mt-20">
+        등록된 추가 정보가 없어서 맞춤형 정보를 제공해 드리기 어려워요.
+      </p>
+      <p class="text-2xl font-semibold text-gray-800 text-center mb-20">
+        추가 정보를 등록하시겠습니까?
+        <span
+          @click="openModal"
+          class="cursor-pointer text-xl text-darkBlue underline hover:text-midBlue"
+        >
+          등록하러 가기
+        </span>
+      </p>
+    </div>
+
+    <div
+      v-if="showModal"
+      class="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50"
+    >
+      <div class="bg-white p-6 rounded-lg shadow-lg max-w-xl w-full">
+        <p class="text-2xl font-bold mb-4">추가 정보 등록</p>
+
+        <p class="flex items-center mb-4">
+          <span class="w-1/5 text-xl font-semibold">지역</span>
+          <select class="w-4/5 py-2" v-model="member.region">
+            <option value="null" disabled>지역 선택</option>
+            <option v-for="city in cities" :key="city" :value="city">
+              {{ city }}
+            </option>
+          </select>
+        </p>
+
+        <p class="flex items-center mb-4">
+          <span class="w-1/5 text-xl font-semibold">지역구</span>
+          <select class="w-4/5 py-2" v-model="member.district">
+            <option value="null" disabled>지역구 선택</option>
+            <option
+              v-for="district in districts"
+              :key="district"
+              :value="district"
+            >
+              {{ district }}
+            </option>
+          </select>
+        </p>
+
+        <p class="flex items-center mb-4">
+          <span class="w-1/5 text-xl font-semibold">읍/면/동</span>
+          <select class="w-4/5 py-2" v-model="member.local">
+            <option value="null" disabled>동 선택</option>
+            <option v-for="local in locals" :key="local" :value="local">
+              {{ local }}
+            </option>
+          </select>
+        </p>
+
+        <p class="flex items-center mb-4">
+          <span class="w-1/5 text-xl font-semibold">주거 형태</span>
+          <select class="w-4/5 py-2" v-model="member.housingType">
+            <option value="null" disabled>주거 형태 선택</option>
+            <option value="아파트">아파트</option>
+            <option value="오피스텔">오피스텔</option>
+            <option value="연립 주택">연립 주택</option>
+            <option value="단독 주택">단독 주택</option>
+            <option value="기타">기타</option>
+          </select>
+        </p>
+
+        <p class="flex items-center mb-4">
+          <span class="w-1/5 text-xl font-semibold">직업</span>
+          <select class="w-4/5 py-2" v-model="member.occupation">
+            <option value="null" disabled>직업 선택</option>
+            <option value="직장인">직장인</option>
+            <option value="사업가">사업가</option>
+            <option value="프리랜서">프리랜서</option>
+            <option value="취업 준비생">취업 준비생</option>
+            <option value="학생">학생</option>
+            <option value="기타">기타</option>
+          </select>
+        </p>
+
+        <p class="flex items-center mb-4">
+          <span class="w-1/5 text-xl font-semibold">결혼 여부</span>
+          <select class="w-4/5 py-2" v-model="member.maritalStatus">
+            <option value="null" disabled>결혼 여부 선택</option>
+            <option value="1">O</option>
+            <option value="0">X</option>
+          </select>
+        </p>
+
+        <p class="flex items-center mb-4">
+          <span class="w-1/5 text-xl font-semibold">자녀 유무</span>
+          <select class="w-4/5 py-2" v-model="member.hasChildren">
+            <option value="null" disabled>자녀 유무 선택</option>
+            <option value="1">O</option>
+            <option value="0">X</option>
+          </select>
+        </p>
+
+        <div class="flex justify-center mt-6 space-x-10">
+          <button
+            @click="submitInfo"
+            class="px-4 py-2 bg-darkBlue text-white rounded"
+          >
+            저장
+          </button>
+
+          <button
+            @click="closeModal"
+            class="px-4 py-2 bg-darkBlue text-white rounded"
+          >
+            취소
+          </button>
         </div>
       </div>
     </div>
   </div>
-
   <div v-else>
-    <p class="text-2xl font-semibold text-gray-800 text-center mb-10 mt-20">
-      등록된 추가 정보가 없어서 맞춤형 정보를 제공해 드리기 어려워요.
-    </p>
-    <p class="text-2xl font-semibold text-gray-800 text-center mb-20">
-      추가 정보를 등록하시겠습니까?
-      <span
-        @click="openModal"
-        class="cursor-pointer text-xl text-darkBlue underline hover:text-midBlue"
+    <div class="text-center mt-20">
+      <p class="text-3xl font-semibold text-darkBlue mb-10">
+        로그인하지 않은 상태입니다.
+      </p>
+      <p class="text-xl text-darkBlue">
+        로그인하시면 맞춤형 정보를 확인할 수 있습니다.
+      </p>
+      <div
+        class="text-base px-4 py-2 text-darkBlue rounded mt-4 underline cursor-pointer"
+        @click="$router.push({ name: 'login' })"
       >
-        등록하러 가기
-      </span>
-    </p>
-  </div>
-
-  <div
-    v-if="showModal"
-    class="fixed inset-0 bg-gray-600 bg-opacity-50 flex justify-center items-center z-50"
-  >
-    <div class="bg-white p-6 rounded-lg shadow-lg max-w-xl w-full">
-      <p class="text-2xl font-bold mb-4">추가 정보 등록</p>
-
-      <p class="flex items-center mb-4">
-        <span class="w-1/5 text-xl font-semibold">지역</span>
-        <select class="w-4/5 py-2" v-model="member.region">
-          <option value="null" disabled>지역 선택</option>
-          <option v-for="city in cities" :key="city" :value="city">
-            {{ city }}
-          </option>
-        </select>
-      </p>
-
-      <p class="flex items-center mb-4">
-        <span class="w-1/5 text-xl font-semibold">지역구</span>
-        <select class="w-4/5 py-2" v-model="member.district">
-          <option value="null" disabled>지역구 선택</option>
-          <option
-            v-for="district in districts"
-            :key="district"
-            :value="district"
-          >
-            {{ district }}
-          </option>
-        </select>
-      </p>
-
-      <p class="flex items-center mb-4">
-        <span class="w-1/5 text-xl font-semibold">읍/면/동</span>
-        <select class="w-4/5 py-2" v-model="member.local">
-          <option value="null" disabled>동 선택</option>
-          <option v-for="local in locals" :key="local" :value="local">
-            {{ local }}
-          </option>
-        </select>
-      </p>
-
-      <p class="flex items-center mb-4">
-        <span class="w-1/5 text-xl font-semibold">주거 형태</span>
-        <select class="w-4/5 py-2" v-model="member.housingType">
-          <option value="null" disabled>주거 형태 선택</option>
-          <option value="아파트">아파트</option>
-          <option value="오피스텔">오피스텔</option>
-          <option value="연립 주택">연립 주택</option>
-          <option value="단독 주택">단독 주택</option>
-          <option value="기타">기타</option>
-        </select>
-      </p>
-
-      <p class="flex items-center mb-4">
-        <span class="w-1/5 text-xl font-semibold">직업</span>
-        <select class="w-4/5 py-2" v-model="member.occupation">
-          <option value="null" disabled>직업 선택</option>
-          <option value="직장인">직장인</option>
-          <option value="사업가">사업가</option>
-          <option value="프리랜서">프리랜서</option>
-          <option value="취업 준비생">취업 준비생</option>
-          <option value="학생">학생</option>
-          <option value="기타">기타</option>
-        </select>
-      </p>
-
-      <p class="flex items-center mb-4">
-        <span class="w-1/5 text-xl font-semibold">결혼 여부</span>
-        <select class="w-4/5 py-2" v-model="member.maritalStatus">
-          <option value="null" disabled>결혼 여부 선택</option>
-          <option value="1">O</option>
-          <option value="0">X</option>
-        </select>
-      </p>
-
-      <p class="flex items-center mb-4">
-        <span class="w-1/5 text-xl font-semibold">자녀 유무</span>
-        <select class="w-4/5 py-2" v-model="member.hasChildren">
-          <option value="null" disabled>자녀 유무 선택</option>
-          <option value="1">O</option>
-          <option value="0">X</option>
-        </select>
-      </p>
-
-      <div class="flex justify-center mt-6 space-x-10">
-        <button
-          @click="submitInfo"
-          class="px-4 py-2 bg-darkBlue text-white rounded"
-        >
-          저장
-        </button>
-
-        <button
-          @click="closeModal"
-          class="px-4 py-2 bg-darkBlue text-white rounded"
-        >
-          취소
-        </button>
+        로그인 하러 가기
       </div>
     </div>
   </div>

--- a/src/views/policy/PolicyDetailPage.vue
+++ b/src/views/policy/PolicyDetailPage.vue
@@ -207,7 +207,9 @@ const formatPolicySubject = (text) => {
           </div>
           <div class="content-row mb-4">
             <span class="title-cell">나이</span>
-            <span class="content-cell">{{ policyDetail?.minAge }} ~ {{ policyDetail?.maxAge }}</span>
+            <span class="content-cell"
+              >{{ policyDetail?.minAge }} ~ {{ policyDetail?.maxAge }}</span
+            >
           </div>
           <div class="content-row mb-4">
             <span class="title-cell">직업</span>
@@ -242,7 +244,7 @@ const formatPolicySubject = (text) => {
         </ul>
 
         <!-- 뒤로 가기 링크 -->
-        <router-link to="/" class="text-blue-500 mt-4 inline-block"
+        <router-link to="/policy" class="text-blue-500 mt-4 inline-block"
           >뒤로 가기</router-link
         >
       </div>
@@ -326,7 +328,7 @@ const formatPolicySubject = (text) => {
 }
 
 .right-nav {
-  position: sticky;
+  position: absolute;
   top: 0;
   right: 0;
   width: 20%;
@@ -335,10 +337,6 @@ const formatPolicySubject = (text) => {
   padding-top: 20px;
   max-height: calc(100vh - 80px);
   overflow-y: auto;
-}
-
-.right-nav.fixed {
-  position: fixed;
 }
 
 .section-title {

--- a/src/views/policy/PolicyRecommandPage.vue
+++ b/src/views/policy/PolicyRecommandPage.vue
@@ -1,60 +1,56 @@
 <script setup>
 import FilterSection from "@/components/home/FilterSection.vue";
 import { usePolicyStore } from "@/stores/policy.js";
-import { ref, onMounted, onBeforeUnmount } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount } from "vue";
 
 const policyStore = usePolicyStore();
 const policyList = ref([]);
 
-// const pageGroup = ref(0);
-// const currentPage = ref(1);
-// const itemsPerPage = 10;
+const currentPage = ref(1);
+const itemsPerPage = 10;
+const pageGroupSize = 5;
 
-// const totalPages = computed(() =>
-//   Math.ceil(policyList.value.length / itemsPerPage)
-// );
+const totalPages = computed(() =>
+  Math.ceil(policyList.value.length / itemsPerPage)
+);
 
-// const visiblePages = computed(() => {
-//   const start = pageGroup.value * 5 + 1;
-//   const end = Math.min(start + 4, totalPages.value);
-//   return Array.from({ length: end - start + 1 }, (_, i) => start + i);
-// });
+const paginatedPolicies = computed(() => {
+  const start = (currentPage.value - 1) * itemsPerPage;
+  const end = start + itemsPerPage;
+  return policyList.value.slice(start, end);
+});
 
-// const changePage = (page) => {
-//   if (page > 0 && page <= totalPages.value) {
-//     currentPage.value = page;
-//     localStorage.setItem("page", page);
-//   }
-// };
+const currentGroup = computed(() =>
+  Math.ceil(currentPage.value / pageGroupSize)
+);
 
-// const nextPageGroup = () => {
-//   if (pageGroup.value < Math.floor(totalPages.value / 5)) {
-//     pageGroup.value++;
-//     currentPage.value = pageGroup.value * 5 + 1;
-//   }
-// };
+const visiblePages = computed(() => {
+  const startPage = (currentGroup.value - 1) * pageGroupSize + 1;
+  const endPage = Math.min(startPage + pageGroupSize - 1, totalPages.value);
+  return Array.from(
+    { length: endPage - startPage + 1 },
+    (_, i) => startPage + i
+  );
+});
 
-// const previousPageGroup = () => {
-//   if (pageGroup.value > 0) {
-//     pageGroup.value--;
-//     currentPage.value = pageGroup.value * 5 + 1;
-//   }
-// };
+const changePage = (page) => {
+  if (page > 0 && page <= totalPages.value) {
+    currentPage.value = page;
+    localStorage.setItem("page", page);
+  }
+};
 
-// const paginatedPolicies = computed(() => {
-//   const start = (currentPage.value - 1) * itemsPerPage;
-//   const end = start + itemsPerPage;
-//   console.log(
-//     "Slicing from",
-//     start,
-//     "to",
-//     end,
-//     "in list of length",
-//     policyList.value.length
-//   );
+const previousPageGroup = () => {
+  if (currentGroup.value > 1) {
+    currentPage.value = (currentGroup.value - 1) * pageGroupSize;
+  }
+};
 
-//   return policyList.value.slice(start, end);
-// });
+const nextPageGroup = () => {
+  if (currentGroup.value * pageGroupSize < totalPages.value) {
+    currentPage.value = currentGroup.value * pageGroupSize + 1;
+  }
+};
 
 const formatDate = (dateString) => {
   if (!dateString) return "";
@@ -68,6 +64,11 @@ const updatePolicyList = () => {
 
 onMounted(() => {
   window.addEventListener("filters-applied", updatePolicyList);
+
+  const savedPage = localStorage.getItem("page");
+  if (savedPage) {
+    currentPage.value = parseInt(savedPage, 10);
+  }
 });
 
 onBeforeUnmount(() => {
@@ -82,13 +83,13 @@ onBeforeUnmount(() => {
     <div class="flex border-t-4 border-darkBlue py-4"></div>
 
     <ul>
-      <li v-if="policyList.length === 0">
+      <li v-if="paginatedPolicies.length === 0">
         <p class="text-center text-gray-500">검색한 결과가 없습니다.</p>
       </li>
 
       <li
         v-else
-        v-for="(policy, index) in policyList"
+        v-for="(policy, index) in paginatedPolicies"
         :key="index"
         class="hover:bg-gray-100 cursor-pointer flex items-center space-x-10 border-t border-gray-200 p-2"
         @click="
@@ -117,5 +118,35 @@ onBeforeUnmount(() => {
         </div>
       </li>
     </ul>
+
+    <div class="flex justify-center mt-4 space-x-2">
+      <button
+        class="px-4 py-2 rounded-md border border-gray-300 text-darkBlue"
+        :disabled="currentGroup.value === 1"
+        @click="previousPageGroup"
+      >
+        이전
+      </button>
+      <button
+        v-for="page in visiblePages"
+        :key="page"
+        :class="[
+          'px-4 py-2 rounded-md',
+          page === currentPage
+            ? 'bg-darkBlue text-white'
+            : 'border border-gray-300 text-darkBlue',
+        ]"
+        @click="changePage(page)"
+      >
+        {{ page }}
+      </button>
+      <button
+        class="px-4 py-2 rounded-md border border-gray-300 text-darkBlue"
+        :disabled="currentGroup.value * pageGroupSize >= totalPages.value"
+        @click="nextPageGroup"
+      >
+        다음
+      </button>
+    </div>
   </div>
 </template>

--- a/src/views/policy/PolicyRecommandPage.vue
+++ b/src/views/policy/PolicyRecommandPage.vue
@@ -172,10 +172,10 @@ const updateFilters = (filters) => {
 
 <template>
   <section
-    class="bg-gray-800 text-white p-4 rounded-lg mt-6 flex mx-auto flex-col items-center gap-4 md:gap-2 shadow-md w-[90%] md:flex-row md:flex-wrap md:justify-center max-w-8xl w-full"
+    class="text-white p-4 rounded-lg mt-6 flex mx-auto flex-col items-center gap-4 md:gap-2 w-[90%] md:flex-row md:flex-wrap md:justify-center"
   >
     <div
-      class="flex items-center space-x-2 bg-darkBlue text-white px-3 py-2 rounded-lg md:rounded-l-lg w-full md:w-auto"
+      class="flex items-center space-x-2 bg-[#002842] text-white px-4 py-3 rounded-lg md:rounded-l-lg w-full md:w-auto"
     >
       <i class="fas fa-users"></i>
       <strong class="text-lg font-semibold">정책 검색</strong>

--- a/src/views/policy/PolicyRecommandPage.vue
+++ b/src/views/policy/PolicyRecommandPage.vue
@@ -1,129 +1,60 @@
 <script setup>
+import FilterSection from "@/components/home/FilterSection.vue";
 import { usePolicyStore } from "@/stores/policy.js";
-import { ref, computed, onMounted } from "vue";
+import { ref, onMounted, onBeforeUnmount } from "vue";
 
 const policyStore = usePolicyStore();
 const policyList = ref([]);
 
-const selectedCity = ref(null);
-const district = ref(null);
-const selectedPolicyType = ref(null);
-const selectedAge = ref(null);
-const selectedJob = ref(null);
-const selectedName = ref(null);
+// const pageGroup = ref(0);
+// const currentPage = ref(1);
+// const itemsPerPage = 10;
 
-const pageGroup = ref(0);
-const currentPage = ref(1);
-const itemsPerPage = 10;
+// const totalPages = computed(() =>
+//   Math.ceil(policyList.value.length / itemsPerPage)
+// );
 
-const totalPages = computed(() =>
-  Math.ceil(policyList.value.length / itemsPerPage)
-);
+// const visiblePages = computed(() => {
+//   const start = pageGroup.value * 5 + 1;
+//   const end = Math.min(start + 4, totalPages.value);
+//   return Array.from({ length: end - start + 1 }, (_, i) => start + i);
+// });
 
-const visiblePages = computed(() => {
-  const start = pageGroup.value * 5 + 1;
-  const end = Math.min(start + 4, totalPages.value);
-  return Array.from({ length: end - start + 1 }, (_, i) => start + i);
-});
+// const changePage = (page) => {
+//   if (page > 0 && page <= totalPages.value) {
+//     currentPage.value = page;
+//     localStorage.setItem("page", page);
+//   }
+// };
 
-const changePage = (page) => {
-  if (page > 0 && page <= totalPages.value) {
-    currentPage.value = page;
-    localStorage.setItem("page", page);
-  }
-};
+// const nextPageGroup = () => {
+//   if (pageGroup.value < Math.floor(totalPages.value / 5)) {
+//     pageGroup.value++;
+//     currentPage.value = pageGroup.value * 5 + 1;
+//   }
+// };
 
-const nextPageGroup = () => {
-  if (pageGroup.value < Math.floor(totalPages.value / 5)) {
-    pageGroup.value++;
-    currentPage.value = pageGroup.value * 5 + 1;
-  }
-};
+// const previousPageGroup = () => {
+//   if (pageGroup.value > 0) {
+//     pageGroup.value--;
+//     currentPage.value = pageGroup.value * 5 + 1;
+//   }
+// };
 
-const previousPageGroup = () => {
-  if (pageGroup.value > 0) {
-    pageGroup.value--;
-    currentPage.value = pageGroup.value * 5 + 1;
-  }
-};
+// const paginatedPolicies = computed(() => {
+//   const start = (currentPage.value - 1) * itemsPerPage;
+//   const end = start + itemsPerPage;
+//   console.log(
+//     "Slicing from",
+//     start,
+//     "to",
+//     end,
+//     "in list of length",
+//     policyList.value.length
+//   );
 
-const paginatedPolicies = computed(() => {
-  const start = (currentPage.value - 1) * itemsPerPage;
-  const end = start + itemsPerPage;
-  return policyList.value.slice(start, end);
-});
-
-const cities = [
-  "서울",
-  "부산",
-  "대구",
-  "인천",
-  "광주",
-  "대전",
-  "울산",
-  "세종",
-  "경기",
-  "강원",
-  "충북",
-  "충남",
-  "전북",
-  "전남",
-  "경상북도",
-  "경남",
-  "제주",
-];
-const policyTypes = [
-  "일자리(창업)",
-  "일자리(취업)",
-  "건강",
-  "교육",
-  "금융",
-  "문화",
-  "복지",
-  "주거비 지원",
-  "주택공급",
-  "참여",
-];
-
-const applyFilters = async () => {
-  localStorage.setItem("selectedCity", selectedCity.value);
-  localStorage.setItem("district", district.value);
-  localStorage.setItem("selectedPolicyType", selectedPolicyType.value);
-  localStorage.setItem("selectedAge", selectedAge.value);
-  localStorage.setItem("selectedJob", selectedJob.value);
-  localStorage.setItem("selectedName", selectedName.value);
-
-  policyStore.filterCondition.city =
-    selectedCity.value === "전체" || selectedCity.value === "null"
-      ? null
-      : selectedCity.value;
-
-  policyStore.filterCondition.district =
-    district.value === "" || district.value === "null" ? null : district.value;
-
-  policyStore.filterCondition.type =
-    selectedPolicyType.value === "전체" || selectedPolicyType.value === "null"
-      ? null
-      : selectedPolicyType.value;
-
-  policyStore.filterCondition.age =
-    selectedAge.value === "" || selectedAge.value === "null"
-      ? null
-      : selectedAge.value;
-
-  policyStore.filterCondition.job =
-    selectedJob.value === "전체" || selectedJob.value === "null"
-      ? null
-      : selectedJob.value;
-
-  policyStore.filterCondition.name =
-    selectedName.value === "" || selectedName.value === "null"
-      ? null
-      : selectedName.value;
-
-  await policyStore.getPolicyFilter();
-  policyList.value = policyStore.PolicyInfoList;
-};
+//   return policyList.value.slice(start, end);
+// });
 
 const formatDate = (dateString) => {
   if (!dateString) return "";
@@ -131,167 +62,33 @@ const formatDate = (dateString) => {
   return date.toISOString().split("T")[0];
 };
 
+const updatePolicyList = () => {
+  policyList.value = policyStore.PolicyInfoList || [];
+};
+
 onMounted(() => {
-  selectedCity.value = localStorage.getItem("selectedCity") || null;
-  district.value = localStorage.getItem("district") || "";
-  selectedPolicyType.value = localStorage.getItem("selectedPolicyType") || null;
-  selectedAge.value = localStorage.getItem("selectedAge") || "";
-  selectedJob.value = localStorage.getItem("selectedJob") || null;
-  selectedName.value = localStorage.getItem("selectedName") || "";
-
-  const savedPage = localStorage.getItem("page");
-  if (savedPage) {
-    currentPage.value = parseInt(savedPage, 10);
-    pageGroup.value = Math.floor((currentPage.value - 1) / 5);
-  } else {
-    currentPage.value = 1;
-    pageGroup.value = 0;
-  }
-
-  if (
-    selectedCity.value ||
-    district.value ||
-    selectedPolicyType.value ||
-    selectedAge.value ||
-    selectedJob.value ||
-    selectedName.value
-  ) {
-    applyFilters();
-  }
+  window.addEventListener("filters-applied", updatePolicyList);
 });
 
-const updateFilters = (filters) => {
-  selectedCity.value = filters.selectedCity;
-  district.value = filters.district;
-  selectedPolicyType.value = filters.selectedPolicyType;
-  selectedAge.value = filters.selectedAge;
-  selectedJob.value = filters.selectedJob;
-  selectedName.value = filters.selectedName;
-};
+onBeforeUnmount(() => {
+  window.removeEventListener("filters-applied", updatePolicyList);
+});
 </script>
 
 <template>
-  <section
-    class="text-white p-4 rounded-lg mt-6 flex mx-auto flex-col items-center gap-4 md:gap-2 w-[90%] md:flex-row md:flex-wrap md:justify-center"
-  >
-    <div
-      class="flex items-center space-x-2 bg-[#002842] text-white px-4 py-3 rounded-lg md:rounded-l-lg w-full md:w-auto"
-    >
-      <i class="fas fa-users"></i>
-      <strong class="text-lg font-semibold">정책 검색</strong>
-    </div>
-
-    <div
-      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
-    >
-      <i class="fas fa-map-marker-alt text-gray-500"></i>
-      <select
-        v-model="selectedCity"
-        class="bg-transparent w-full focus:outline-none"
-      >
-        <option value="null">전체</option>
-        <option v-for="city in cities" :key="city" :value="city">
-          {{ city }}
-        </option>
-      </select>
-    </div>
-
-    <div
-      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
-    >
-      <i class="fa-solid fa-location-arrow text-gray-500"></i>
-      <input
-        v-model="district"
-        id="district"
-        type="text"
-        placeholder="지역구를 입력해 주세요."
-        class="bg-transparent w-full focus:outline-none"
-      />
-    </div>
-
-    <div
-      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
-    >
-      <i class="fas fa-briefcase text-gray-500"></i>
-      <select
-        v-model="selectedJob"
-        class="bg-transparent w-full focus:outline-none"
-      >
-        <option value="null">전체</option>
-        <option value="학생">학생</option>
-        <option value="무직">무직</option>
-        <option value="직장인">직장인</option>
-        <option value="자영업">자영업</option>
-        <option value="프리랜서">프리랜서</option>
-        <option value="(예비)창업자">(예비)창업자</option>
-        <option value="일용근로자">일용근로자</option>
-        <option value="단기근로자">단기근로자</option>
-        <option value="영농종사자">영농종사자</option>
-      </select>
-    </div>
-
-    <div
-      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
-    >
-      <i class="fas fa-user text-gray-500"></i>
-      <input
-        v-model="selectedAge"
-        id="selectedAge"
-        type="text"
-        placeholder="나이를 입력해 주세요."
-        class="bg-transparent w-full focus:outline-none"
-      />
-    </div>
-
-    <div
-      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
-    >
-      <i class="fa-solid fa-check text-gray-500"></i>
-      <select
-        v-model="selectedPolicyType"
-        class="bg-transparent w-full focus:outline-none"
-      >
-        <option value="null">전체</option>
-        <option v-for="type in policyTypes" :key="type" :value="type">
-          {{ type }}
-        </option>
-      </select>
-    </div>
-
-    <div
-      class="flex items-center space-x-2 bg-white text-black p-2 border border-gray-300 rounded-md w-full md:w-auto"
-    >
-      <i class="fas fa-search"></i>
-      <input
-        v-model="selectedName"
-        id="selectedName"
-        type="text"
-        placeholder="정책명을 입력해 주세요."
-        class="bg-transparent w-full focus:outline-none"
-      />
-    </div>
-
-    <button
-      @click="applyFilters"
-      class="bg-darkBlue px-4 py-2 rounded-lg w-full md:w-auto flex items-center justify-center"
-    >
-      <i class="fas fa-search"></i>
-      <span class="ml-1">검색</span>
-    </button>
-  </section>
-
+  <FilterSection />
   <div class="mx-auto p-4 w-full max-w-8xl">
     <p class="text-2xl font-bold mb-4 text-[32px]">정책 정보</p>
     <div class="flex border-t-4 border-darkBlue py-4"></div>
 
     <ul>
-      <li v-if="paginatedPolicies.length === 0">
+      <li v-if="policyList.length === 0">
         <p class="text-center text-gray-500">검색한 결과가 없습니다.</p>
       </li>
 
       <li
         v-else
-        v-for="(policy, index) in paginatedPolicies"
+        v-for="(policy, index) in policyList"
         :key="index"
         class="hover:bg-gray-100 cursor-pointer flex items-center space-x-10 border-t border-gray-200 p-2"
         @click="
@@ -320,37 +117,5 @@ const updateFilters = (filters) => {
         </div>
       </li>
     </ul>
-
-    <div class="flex justify-center mt-4 space-x-2">
-      <button
-        class="px-4 py-2 rounded-md border border-gray-300 text-darkBlue"
-        @click="previousPageGroup"
-        :disabled="pageGroup === 0"
-      >
-        이전
-      </button>
-
-      <button
-        v-for="page in visiblePages"
-        :key="page"
-        @click="changePage(page)"
-        :class="[
-          'px-4 py-2 rounded-md',
-          page === currentPage
-            ? 'bg-darkBlue text-white'
-            : 'border border-gray-300 text-darkBlue',
-        ]"
-      >
-        {{ page }}
-      </button>
-
-      <button
-        class="px-4 py-2 rounded-md border border-gray-300 text-darkBlue"
-        @click="nextPageGroup"
-        :disabled="pageGroup >= Math.floor(totalPages.value / 5)"
-      >
-        다음
-      </button>
-    </div>
   </div>
 </template>


### PR DESCRIPTION
### #️⃣ 24.11.17

### 📝 작업 내용
- 비로그인 시 정책페이지에서 전체 정책 리스트 나오도록 수정
- 정책 필터링 컴포넌트로 구분 후 이에 따라 페이지네이션 오류로 재구현
- 나만의 서비스 비로그인 시 UI 구현(로그인페이지로 바로 이동하지 않도록 수정)
- 정책 상세보기에서 오른쪽 네비게이션 위치 고정되도록 수정

### 💬 리뷰 요구사항
1. 비로그인 시 정책페이지에서 전체 정책 리스트 나오는지 확인해 주세요.
2. 나만의 서비스에서 비로그인 시 UI 확인해 주세요.
3. 정책 상세보기 페이지에서 오른쪽 네비게이션 위치 고정되는지 확인해 주세요.

### 스크린샷
나만의 서비스 비로그인 시 화면
<img width="1049" alt="image" src="https://github.com/user-attachments/assets/57daf32a-e502-4351-8dd0-96db4a63c74b">
