### PR TITLE
Feat: 알림 설정 ON/OFF 기능 개선

### DIFF
--- a/src/components/notification/MemberNotification.vue
+++ b/src/components/notification/MemberNotification.vue
@@ -14,6 +14,8 @@ const notificationStore = useNotificationStore();
 const authStore = useAuthStore();
 const isLiked = ref(false);
 const isLoading = ref(false);
+const notificationStatus = ref(false); // 알림 설정 상태
+const showAlertMessage = ref(false); // 팝업 표시 상태
 
 const toggleLike = async () => {
   if (!authStore.isUserLoggedIn) {
@@ -21,7 +23,13 @@ const toggleLike = async () => {
     return;
   }
 
-  isLoading.value = true; 
+  if (!notificationStatus.value) {
+    // 알림 설정이 꺼져있을 경우 팝업 표시
+    showAlertMessage.value = true;
+    return;
+  }
+
+  isLoading.value = true;
   try {
     if (isLiked.value) {
       await notificationStore.deleteNotification(props.policyIdx);
@@ -30,12 +38,12 @@ const toggleLike = async () => {
       await notificationStore.updateNotification(props.policyIdx, true);
       alert("알림이 설정되었습니다.");
     }
-    isLiked.value = !isLiked.value; 
+    isLiked.value = !isLiked.value;
   } catch (error) {
     console.error("알림 상태 변경 실패:", error);
     alert("알림 상태 변경에 실패하였습니다.");
   } finally {
-    isLoading.value = false; 
+    isLoading.value = false;
   }
 };
 
@@ -47,16 +55,49 @@ const fetchInitialLikeStatus = async () => {
 
   try {
     await notificationStore.fetchUserNotifications();
+
     const userNotifications = notificationStore.userNotifications;
-    isLiked.value = userNotifications.some(
-      (notification) => notification.policyIdx === props.policyIdx
+
+    console.log("User Notifications:", userNotifications);
+    console.log("Policy Index (props):", props.policyIdx);
+
+    // 매칭되는 항목 찾기
+    const matchingNotifications = userNotifications.filter(
+      (notification) =>
+        Number(notification.policyIdx) === Number(props.policyIdx)
     );
+
+    console.log("Matching Notifications:", matchingNotifications);
+
+    // 좋아요 상태 설정
+    isLiked.value = matchingNotifications.some(
+      (notification) => Number(notification.notification_enabled) === 1
+    );
+
+    console.log("Is Policy Liked:", isLiked.value);
   } catch (error) {
     console.error("알림 상태 로드 실패:", error);
   }
 };
 
-onMounted(fetchInitialLikeStatus);
+const fetchNotificationStatus = async () => {
+  try {
+    const response = await notificationStore.fetchNotificationStatus();
+    notificationStatus.value = response.notificationEnabled; // 알림 설정 상태 저장
+    console.log("Notification Status:", notificationStatus.value);
+  } catch (error) {
+    console.error("알림 상태 가져오는 중 오류 발생:", error);
+  }
+};
+
+const closeAlert = () => {
+  showAlertMessage.value = false;
+};
+
+onMounted(async () => {
+  await fetchNotificationStatus(); // 알림 상태 초기화
+  await fetchInitialLikeStatus(); // 좋아요 상태 초기화
+});
 
 watch(() => props.policyIdx, fetchInitialLikeStatus);
 </script>
@@ -71,6 +112,44 @@ watch(() => props.policyIdx, fetchInitialLikeStatus);
       <span v-if="isLiked">❤️</span>
       <span v-else>🤍</span>
     </button>
+
+    <!-- 팝업 -->
+    <div
+      v-if="showAlertMessage"
+      class="alert-popup fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+    >
+      <div class="popup-content bg-white rounded-lg shadow-lg p-6 max-w-sm w-full relative">
+        <button
+          class="close-button absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+          @click="closeAlert"
+        >
+          ✕
+        </button>
+        <p class="text-gray-700 text-sm">
+            <strong>현재 알림 설정이 꺼져 있습니다.</strong><br /><br />
+            마이페이지에서 "알림 설정"을 ON으로 변경하시면 이 기능을 이용하실 수 있습니다. 😊<br /><br />
+            
+            <strong>변경 방법</strong><br />
+            1. 상단 메뉴에서 "마이페이지"로 이동하세요.<br />
+            2. "알림 설정" 스위치를 ON으로 전환하세요.<br />
+            3. 설정 후 이 페이지로 돌아오시면 하트 버튼을 사용할 수 있습니다!<br /><br />
+            
+            <br />
+            <strong>알림 설정을 활성화하면 이런 혜택을 누릴 수 있습니다! 🎉<br /></strong><br />
+                1. <b>맞춤형 추천 알림 서비스</b> <br />
+                - 사용자 맞춤형 정책 및 프로그램을 추천해드립니다.<br />
+                - 새로운 기회와 혜택을 누구보다 먼저 확인하세요!<br /><br />
+                2. <b>찜한 정책의 중요한 알림 제공</b> <br />
+                - 하트를 누른 정책은 마감 3일 전에 미리 이메일로 알려드립니다.<br />
+                - 마감 하루 전에는 추가 알림을 보내드려 중요한 기회를 놓치지 않도록 도와드립니다.<br /><br />
+                3. <b>효율적인 정책 관리</b> <br />
+                - 찜한 정책과 추천받은 정책을 한눈에 확인할 수 있어, <br> 
+                관심 있는 정책을 손쉽게 관리할 수 있습니다.<br /><br />
+                <b>알림 설정은 정책 관리의 시작입니다. 지금 활성화하고 더 많은 혜택을 누려보세요! 😊</b>
+            </p>
+
+      </div>
+    </div>
   </div>
 </template>
 
@@ -97,5 +176,46 @@ button:not(.liked) {
 button:disabled {
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+/* 팝업 스타일 */
+.alert-popup {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 50;
+}
+
+.popup-content {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  position: relative;
+}
+
+.close-button {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.7rem;
+  background: none;
+  border: none;
+  font-size: 0.7rem;
+  cursor: pointer;
+  color: #000000;
+}
+
+.close-button:hover {
+  color: #000;
+}
+
+.text-gray-700 {
+  color: #4a5568;
 }
 </style>

--- a/src/components/notification/MemberNotification.vue
+++ b/src/components/notification/MemberNotification.vue
@@ -14,8 +14,8 @@ const notificationStore = useNotificationStore();
 const authStore = useAuthStore();
 const isLiked = ref(false);
 const isLoading = ref(false);
-const notificationStatus = ref(false); // 알림 설정 상태
-const showAlertMessage = ref(false); // 팝업 표시 상태
+const notificationStatus = ref(false); 
+const showAlertMessage = ref(false); 
 
 const toggleLike = async () => {
   if (!authStore.isUserLoggedIn) {
@@ -24,7 +24,6 @@ const toggleLike = async () => {
   }
 
   if (!notificationStatus.value) {
-    // 알림 설정이 꺼져있을 경우 팝업 표시
     showAlertMessage.value = true;
     return;
   }
@@ -58,23 +57,15 @@ const fetchInitialLikeStatus = async () => {
 
     const userNotifications = notificationStore.userNotifications;
 
-    console.log("User Notifications:", userNotifications);
-    console.log("Policy Index (props):", props.policyIdx);
-
-    // 매칭되는 항목 찾기
     const matchingNotifications = userNotifications.filter(
       (notification) =>
         Number(notification.policyIdx) === Number(props.policyIdx)
     );
 
-    console.log("Matching Notifications:", matchingNotifications);
-
-    // 좋아요 상태 설정
     isLiked.value = matchingNotifications.some(
       (notification) => Number(notification.notification_enabled) === 1
     );
 
-    console.log("Is Policy Liked:", isLiked.value);
   } catch (error) {
     console.error("알림 상태 로드 실패:", error);
   }
@@ -83,8 +74,7 @@ const fetchInitialLikeStatus = async () => {
 const fetchNotificationStatus = async () => {
   try {
     const response = await notificationStore.fetchNotificationStatus();
-    notificationStatus.value = response.notificationEnabled; // 알림 설정 상태 저장
-    console.log("Notification Status:", notificationStatus.value);
+    notificationStatus.value = response.notificationEnabled; 
   } catch (error) {
     console.error("알림 상태 가져오는 중 오류 발생:", error);
   }
@@ -95,8 +85,8 @@ const closeAlert = () => {
 };
 
 onMounted(async () => {
-  await fetchNotificationStatus(); // 알림 상태 초기화
-  await fetchInitialLikeStatus(); // 좋아요 상태 초기화
+  await fetchNotificationStatus(); 
+  await fetchInitialLikeStatus();
 });
 
 watch(() => props.policyIdx, fetchInitialLikeStatus);
@@ -127,7 +117,8 @@ watch(() => props.policyIdx, fetchInitialLikeStatus);
         </button>
         <p class="text-gray-700 text-sm">
             <strong>현재 알림 설정이 꺼져 있습니다.</strong><br /><br />
-            마이페이지에서 "알림 설정"을 ON으로 변경하시면 이 기능을 이용하실 수 있습니다. 😊<br /><br />
+            마이페이지에서 "알림 설정"을 ON으로 변경하시면 
+            <br>이 기능을 이용하실 수 있습니다. 😊<br /><br />
             
             <strong>변경 방법</strong><br />
             1. 상단 메뉴에서 "마이페이지"로 이동하세요.<br />
@@ -178,7 +169,6 @@ button:disabled {
   opacity: 0.6;
 }
 
-/* 팝업 스타일 */
 .alert-popup {
   display: flex;
   align-items: center;

--- a/src/components/notification/NotificationStatus.vue
+++ b/src/components/notification/NotificationStatus.vue
@@ -12,9 +12,9 @@ const notificationStatus = ref(
   JSON.parse(localStorage.getItem("notificationStatus")) || false
 );
 const isModalOpen = ref(false);
-const notifications = ref([]); 
+const notifications = ref([]);
 const isLoading = ref(false);
-
+const showNotificationAlert = ref(false); // 알림 안내 팝업 상태
 const unreadCount = computed(() => notificationStore.unreadNotificationsCount);
 
 const fetchInitialNotificationStatus = async () => {
@@ -52,7 +52,9 @@ const fetchPushNotifications = async () => {
     isLoading.value = true;
     await notificationStore.fetchPushNotifications();
 
-    notifications.value = notificationStore.pushNotifications.filter((n) => !n.isRead).slice(0, 10);
+    notifications.value = notificationStore.pushNotifications
+      .filter((n) => !n.isRead)
+      .slice(0, 10);
 
     console.log("읽지 않은 Push 알림 목록 불러오기 성공:", notifications.value);
   } catch (error) {
@@ -63,8 +65,17 @@ const fetchPushNotifications = async () => {
 };
 
 const openNotificationModal = () => {
+  if (!notificationStatus.value) {
+    // 알림 OFF 상태일 경우 팝업 표시
+    showNotificationAlert.value = true;
+    return;
+  }
   if (isModalOpen.value) return;
   isModalOpen.value = true;
+};
+
+const closeNotificationAlert = () => {
+  showNotificationAlert.value = false;
 };
 
 const closeModal = () => {
@@ -82,10 +93,12 @@ const markAsReadAndNavigate = async (policyIdx) => {
 
     await notificationStore.markNotificationAsRead(policyIdx);
 
-    const index = notifications.value.findIndex((n) => n.policyIdx === policyIdx);
+    const index = notifications.value.findIndex(
+      (n) => n.policyIdx === policyIdx
+    );
     if (index !== -1) {
       notifications.value.splice(index, 1);
-      notificationStore.unreadNotificationsCount -= 1; 
+      notificationStore.unreadNotificationsCount -= 1;
     }
 
     router.push({ path: `/policy/detail/${policyIdx}`, query: { isLiked: true } });
@@ -137,14 +150,28 @@ onMounted(async () => {
     </label>
 
     <!-- 알림 아이콘 -->
-    <div class="notification-icon relative cursor-pointer" @click="openNotificationModal">
+    <div
+      class="notification-icon relative cursor-pointer"
+      :class="{ disabled: !notificationStatus }"
+      @click="openNotificationModal"
+    >
       <span class="icon">🔔</span>
       <span
-        v-if="unreadCount > 0"
+        v-if="unreadCount > 0 && notificationStatus"
         class="absolute top-0 right-0 w-4 h-4 bg-red-500 text-white rounded-full text-xs flex items-center justify-center"
       >
         {{ unreadCount }}
       </span>
+    </div>
+
+    <!-- 알림 팝업 -->
+    <div v-if="showNotificationAlert" class="alert-popup">
+      <div class="popup-content">
+        <p class="text-gray-700">
+          알림 설정을 ON으로 변경해야 이 기능을 사용할 수 있습니다.
+        </p>
+        <button @click="closeNotificationAlert" class="close-button">✕</button>
+      </div>
     </div>
 
     <!-- 모달 -->
@@ -214,6 +241,10 @@ onMounted(async () => {
 .notification-icon .icon {
   font-size: 1.5rem;
 }
+.notification-icon.disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
 .modal {
   position: fixed;
   top: 0;
@@ -234,6 +265,47 @@ onMounted(async () => {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
   z-index: 60;
 }
+
+.alert-popup {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5); 
+  z-index: 50; 
+}
+
+.popup-content {
+  background: white; 
+  padding: 1.5rem;
+  border-radius: 0.5rem; 
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2); 
+  position: relative;
+}
+
+.close-button {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.7rem;
+  background: none;
+  border: none; 
+  font-size: 0.7rem; 
+  cursor: pointer; 
+  color: #000000; 
+}
+
+.close-button:hover {
+  color: #000;
+}
+
+.text-gray-700 {
+  color: #4a5568; 
+}
+
 .bg-blue-500 {
   background-color: #002842;
 }

--- a/src/components/notification/NotificationStatus.vue
+++ b/src/components/notification/NotificationStatus.vue
@@ -14,7 +14,7 @@ const notificationStatus = ref(
 const isModalOpen = ref(false);
 const notifications = ref([]);
 const isLoading = ref(false);
-const showNotificationAlert = ref(false); // 알림 안내 팝업 상태
+const showNotificationAlert = ref(false);
 const unreadCount = computed(() => notificationStore.unreadNotificationsCount);
 
 const fetchInitialNotificationStatus = async () => {
@@ -50,13 +50,15 @@ const handleToggleChange = async () => {
 const fetchPushNotifications = async () => {
   try {
     isLoading.value = true;
+   
     await notificationStore.fetchPushNotifications();
+  
+    notifications.value = notificationStore.pushNotifications.filter((n) => !n.isRead);
 
-    notifications.value = notificationStore.pushNotifications
-      .filter((n) => !n.isRead)
-      .slice(0, 10);
+    localStorage.setItem("pushNotifications", JSON.stringify(notifications.value));
 
-    console.log("읽지 않은 Push 알림 목록 불러오기 성공:", notifications.value);
+    notificationStore.unreadNotificationsCount = notifications.value.length;
+    console.log("Push 알림 동기화 성공:", notifications.value);
   } catch (error) {
     console.error("Push 알림 목록 로드 중 오류:", error);
   } finally {
@@ -66,7 +68,6 @@ const fetchPushNotifications = async () => {
 
 const openNotificationModal = () => {
   if (!notificationStatus.value) {
-    // 알림 OFF 상태일 경우 팝업 표시
     showNotificationAlert.value = true;
     return;
   }
@@ -80,7 +81,6 @@ const closeNotificationAlert = () => {
 
 const closeModal = () => {
   isModalOpen.value = false;
-  notifications.value = [];
 };
 
 const markAsReadAndNavigate = async (policyIdx) => {
@@ -93,11 +93,9 @@ const markAsReadAndNavigate = async (policyIdx) => {
 
     await notificationStore.markNotificationAsRead(policyIdx);
 
-    const index = notifications.value.findIndex(
-      (n) => n.policyIdx === policyIdx
-    );
+    const index = notifications.value.findIndex((n) => n.policyIdx === policyIdx);
     if (index !== -1) {
-      notifications.value.splice(index, 1);
+      notifications.value[index].isRead = true;  
       notificationStore.unreadNotificationsCount -= 1;
     }
 
@@ -114,12 +112,20 @@ const navigateToNotificationSummary = () => {
 onMounted(async () => {
   if (authStore.isLoggedIn && authStore.token) {
     await fetchInitialNotificationStatus();
-    await fetchPushNotifications();
+
+    const cachedPushNotifications = JSON.parse(localStorage.getItem("pushNotifications")) || [];
+    if (cachedPushNotifications.length > 0) {
+      notifications.value = cachedPushNotifications;
+      notificationStore.unreadNotificationsCount = cachedPushNotifications.length;
+    } else {
+      await fetchPushNotifications();
+    }
   } else {
     console.error("로그인 상태가 유효하지 않습니다. 로그인을 다시 시도하세요.");
     router.push({ name: "login" });
   }
 });
+
 </script>
 
 <template>
@@ -156,10 +162,7 @@ onMounted(async () => {
       @click="openNotificationModal"
     >
       <span class="icon">🔔</span>
-      <span
-        v-if="unreadCount > 0 && notificationStatus"
-        class="absolute top-0 right-0 w-4 h-4 bg-red-500 text-white rounded-full text-xs flex items-center justify-center"
-      >
+      <span v-if="unreadCount > 0 && notificationStatus" class="absolute top-0 right-0 w-4 h-4 bg-red-500 text-white rounded-full text-xs flex items-center justify-center">
         {{ unreadCount }}
       </span>
     </div>
@@ -183,14 +186,14 @@ onMounted(async () => {
         <p v-if="isLoading" class="text-center text-gray-500">로딩 중...</p>
 
         <!-- 알림 목록 -->
-        <ul v-else-if="notifications.length > 0" class="space-y-4">
+        <ul v-else-if="notifications.length > 0" class="space-y-2">
           <li
             v-for="(notification, index) in notifications"
             :key="index"
-            :class="[ 
-              'border rounded-lg p-4 flex items-center space-x-4 text-sm cursor-pointer', 
-              notification.isRead ? 'bg-gray-300' : 'bg-white' 
-            ]"
+            :class="[
+              'border rounded-lg p-4 flex items-center space-x-4 text-sm cursor-pointer',
+              notification.isRead ? 'bg-gray-200' : 'bg-white'
+              ]"
             @click="markAsReadAndNavigate(notification.policyIdx)"
           >
             <!-- 라벨 -->
@@ -211,7 +214,7 @@ onMounted(async () => {
           </li>
         </ul>
 
-        <p v-else class="text-center text-gray-500">표시할 Push 알림이 없습니다.</p>
+        <p v-else class="text-center text-gray-500">Push 알림이 없습니다.</p>
 
         <!-- 버튼 -->
         <div class="flex justify-end mt-4">
@@ -261,7 +264,7 @@ onMounted(async () => {
   background: white;
   padding: 20px;
   border-radius: 10px;
-  width: 400px;
+  width: 500px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
   z-index: 60;
 }
@@ -310,13 +313,7 @@ onMounted(async () => {
   background-color: #002842;
 }
 .bg-red-500 {
-  background-color: #ff0000;
-}
-.bg-gray-200 {
-  background-color: #f1f1f1;
-}
-.bg-white {
-  background-color: #ffffff;
+  background-color: #f31616;
 }
 </style>
 

--- a/src/views/auth/NotificationSummary.vue
+++ b/src/views/auth/NotificationSummary.vue
@@ -161,14 +161,13 @@ onMounted(async () => {
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-4 py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
+            <th class="px-6 py-3 text-left text-sm font-medium text-gray-600 uppercase tracking-wider">
               알림 이름
             </th>
-            <th class="py-3 text-left text-xs font-medium text-gray-600 uppercase tracking-wider">
+            <th class="px-5 py-3 text-left text-sm font-medium text-gray-600 uppercase tracking-wider">
               마감일
             </th>
-            <th class="px-3 py-3 text-right text-xs font-medium text-gray-600 uppercase tracking-wider">
-              삭제
+            <th class="px-6 py-3 text-right text-sm font-medium text-gray-600 uppercase tracking-wider">
             </th>
           </tr>
         </thead>
@@ -181,14 +180,14 @@ onMounted(async () => {
               ? handlePolicyClick(notification.policyIdx)
               : console.error('Invalid policyIdx:', notification)"
           >
-            <td class="px-3 py-4 text-sm font-medium text-gray-900">
+            <td class="px-5 py-4 text-sm font-medium text-gray-900">
               {{ notification.policyName }}
             </td>
-            <td class="py-4 text-sm text-gray-500">
+            <td class="px-5 py-4 text-sm text-gray-500">
               {{ notification.applyEndDate === "상시" ? "상시" : notification.applyEndDate }}
             </td>
-            <td class="px-2 py-4 text-right text-sm">
-              <div class="delete-wrapper flex items-center justify-end space-x-2">
+            <td class="px-5 py-4 text-center text-sm">
+              <div class="delete-wrapper flex items-center justify-end">
               <button
                 class="text-red-500 hover:text-red-700"
                 @click.stop="deleteNotification(notification.policyIdx)"
@@ -276,16 +275,5 @@ onMounted(async () => {
   background-color: #0d223d;
   color: white;
   border-color: #0d223d;
-}
-
-.delete-wrapper {
-  display: flex;
-  justify-content: flex-end;
-}
-
-@media (max-width: 768px) {
-  .delete-wrapper {
-    justify-content: flex-start;
-  }
 }
 </style>

--- a/src/views/auth/NotificationSummary.vue
+++ b/src/views/auth/NotificationSummary.vue
@@ -1,17 +1,21 @@
 <script setup>
 import { ref, computed, onMounted } from "vue";
 import { useNotificationStore } from "@/stores/notificationStore";
+import { usePolicyStore } from "@/stores/policy";
+import { useRouter } from "vue-router";
 
-const selectedTab = ref("dashboard"); // 기본 선택된 탭
+
+const router = useRouter(); 
+const selectedTab = ref("dashboard");
 const notificationStore = useNotificationStore();
+const policyStore = usePolicyStore(); 
 
-const page = ref(0); // 현재 페이지
-const size = ref(10); // 한 페이지에 표시할 항목 수
-const totalPages = ref(0); // 전체 페이지 수
+const page = ref(0); 
+const size = ref(10); 
+const totalPages = ref(0); 
 const isLastPage = computed(() => page.value >= totalPages.value - 1);
 const isLoading = ref(false);
 
-// 페이지네이션 계산
 const displayedPages = computed(() => {
   const visiblePageCount = 5;
   const current = page.value;
@@ -30,7 +34,6 @@ const displayedPages = computed(() => {
   return Array.from({ length: end - start + 1 }, (_, i) => start + i);
 });
 
-// 현재 탭 데이터 가져오기
 const currentTabNotifications = computed(() => {
   let allNotifications = [];
 
@@ -45,7 +48,6 @@ const currentTabNotifications = computed(() => {
     allNotifications = notificationStore.recommendedNotifications;
   }
 
- 
 allNotifications.sort((a, b) => {
   const today = new Date();
   const aDate = a.applyEndDate === "상시" ? null : new Date(a.applyEndDate);
@@ -62,41 +64,53 @@ allNotifications.sort((a, b) => {
   return 0;
 });
 
-  // 페이지네이션 데이터 계산
   totalPages.value = Math.ceil(allNotifications.length / size.value);
 
-  // 현재 페이지 데이터 반환
   const startIndex = page.value * size.value;
   const endIndex = startIndex + size.value;
   return allNotifications.slice(startIndex, endIndex);
 });
 
-// 탭 변경 처리
 const selectTab = (tab) => {
   selectedTab.value = tab;
-  page.value = 0; // 페이지 초기화
+  page.value = 0; 
 };
 
-// 페이지네이션: 이전 페이지
 const prevPage = () => {
   if (page.value > 0) {
     page.value--;
   }
 };
 
-// 페이지네이션: 다음 페이지
 const nextPage = () => {
   if (!isLastPage.value) {
     page.value++;
   }
 };
 
-// 특정 페이지로 이동
 const goToPage = (newPage) => {
   page.value = newPage;
 };
 
-// 정책 삭제
+const handlePolicyClick = async (policyIdx) => {
+  try {
+    if (!policyIdx) {
+      console.error("Invalid policyIdx:", policyIdx);
+      return;
+    }
+    console.log("Fetching Policy Detail for idx:", policyIdx);
+
+    await policyStore.getPolicyDetail(policyIdx);
+
+    router.push({
+      path: `/policy/detail/${policyIdx}`,
+      query: { isLiked: true },
+    });
+  } catch (error) {
+    console.error("Error while fetching policy detail:", error);
+  }
+};
+
 const deleteNotification = async (policyIdx) => {
   const confirmDelete = confirm("정말로 삭제하시겠습니까?");
   if (!confirmDelete) return;
@@ -108,7 +122,6 @@ const deleteNotification = async (policyIdx) => {
   }
 };
 
-// 컴포넌트 마운트 시 데이터 로드
 onMounted(async () => {
   await notificationStore.fetchNotificationDashboard();
 });
@@ -164,7 +177,9 @@ onMounted(async () => {
             v-for="notification in currentTabNotifications"
             :key="notification.policyIdx"
             class="hover:bg-gray-50"
-            @click="$router.push(`/policy/detail/${notification.policyIdx}`)"
+            @click="notification.policyIdx 
+              ? handlePolicyClick(notification.policyIdx)
+              : console.error('Invalid policyIdx:', notification)"
           >
             <td class="px-3 py-4 text-sm font-medium text-gray-900">
               {{ notification.policyName }}


### PR DESCRIPTION
### #️⃣ 24.11.18

### 📝 작업 내용
- 정책 알림 설정이 false일 경우
    - 하트 버튼 클릭 시, 팝업 메시지 표시
    - 사용자는 팝업 상단의 닫기 버튼(X)을 클릭하여 팝업을 닫을 수 있습니다.
- 정책알림 설정이 ON일 경우
    - 하트 버튼이 정상적으로 작동하며 팝업이 표시되지 않습니다.
- 마이페이지 알림 아이콘 동작
    - 알림이 OFF 상태일 경우 아이콘 클릭 시 비활성화되고 안내 팝업이 표시됩니다.
    - 알림이 ON 상태일 경우 기존 알림 모달이 표시됩니다.

### 💬 리뷰 요구사항
![image](https://github.com/user-attachments/assets/e924e572-62f7-429b-a1c6-742cd56097f1)
- 전처리가 제대로 안 되어있습니다 전처리 수정 필요

![image](https://github.com/user-attachments/assets/4e163146-a840-44eb-a78d-c854d921d209)
- 해당 정책에 대해 url 클릭 시 이 화면 뜸


### 스크린샷
- push 알림
![image](https://github.com/user-attachments/assets/d844e0d5-1859-473b-a20d-0d0e558b8b1a)

- 알림 off
![image](https://github.com/user-attachments/assets/7d004ef0-419c-49e6-9c38-71565d298f26)
  - 알림 off 시, 알림 on 했던 모든 정책들도  off 로 자동 변경

![image](https://github.com/user-attachments/assets/29524801-7763-41c4-9f14-949cb68b2d9e)
  - 알림 off 인 상태에서 알림  on 클릭할 시 팝업 메시지 적용

![image](https://github.com/user-attachments/assets/aec75ee0-e4da-4235-981b-e38f6af54646)
  -  마이페이지에서도 팝업 메시지 적용

- 알림 on
![image](https://github.com/user-attachments/assets/eb85c234-f429-4f65-a105-98f21569138a)
  - 다시 알림 on 으로 수정하면, 기존에 on으로 했었던 정책 모두 반영
